### PR TITLE
Now()를 SQL 문자열 안으로 옮김

### DIFF
--- a/booths/managers.py
+++ b/booths/managers.py
@@ -1,11 +1,11 @@
 from django.db import models
 from django.db.models import BooleanField
 from django.db.models.expressions import RawSQL
-from django.db.models.functions import Coalesce, Now
+from django.db.models.functions import Coalesce
 
 class BoothManager(models.Manager):
     def get_queryset(self):
-        check_schedule = RawSQL("%s @> ANY(schedule)", (Now(),))
+        check_schedule = RawSQL("Now() @> ANY(schedule)")
 
         return super().get_queryset().annotate(
             is_ongoing=Coalesce(


### PR DESCRIPTION
Now()는 파라미터가 아니라 SQL 함수이므로 SQL 문자열 안에 직접 써야 합니다.