### PR TITLE
Booth, Show 레코드 삽입 커맨드를 stdin 방식으로 리팩토링

### DIFF
--- a/booths/management/commands/insertbooth.py
+++ b/booths/management/commands/insertbooth.py
@@ -21,7 +21,7 @@ python manage.py insertbooth < booth.tsv"""
             raise CommandError(f"파일을 읽는 중 오류가 발생했습니다: {e}")
 
         booth_list = list()
-        for data in data_list:
+        for i, data in enumerate(data_list, start=1):
             try:
                 location = Location.objects.get(
                     building=data['location_building'],
@@ -29,7 +29,7 @@ python manage.py insertbooth < booth.tsv"""
                 )
             except Location.DoesNotExist:
                 raise CommandError(
-                    f"Location 데이터가 올바르지 않습니다. "
+                    f"[{i}번째 행] Location 데이터가 올바르지 않습니다: "
                     f"(building={data['location_building']}, number={data['location_number']})"
                 )
 

--- a/booths/management/commands/insertbooth.py
+++ b/booths/management/commands/insertbooth.py
@@ -1,31 +1,25 @@
+import argparse
 import csv
-import os
 from django.core.management.base import BaseCommand, CommandError
-from utils.helpers import tsv_file
 from booths.models import Booth
 from searchs.models import Location
 
 class Command(BaseCommand):
     help = """Booth 모델에 여러 개의 레코드를 삽입합니다.
-SCP로 EC2에 tsv 파일을 직접 업로드한 후에 명령어를 실행해 주세요."""
+로컬에 파일을 준비한 뒤, 파일이 존재하는 곳에서 명령어를 실행해 주세요."""
 
     def add_arguments(self, parser):
         parser.add_argument(
             '--file',
-            type=tsv_file,
+            type=argparse.FileType('r'),
             required=True,
             help="tsv 파일 경로를 입력해 주세요.",
         )
 
     def handle(self, *args, **options):
-        file_path:str = options['file']
-
-        try:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                reader = csv.DictReader(f, delimiter='\t')
-                data_list = list(reader)
-        except Exception as e:
-            raise CommandError(f"tsv 파일을 읽는 중 오류가 발생했습니다: {e}")
+        file = options['file']
+        reader = csv.DictReader(file, delimiter='\t')
+        data_list = list(reader)
 
         booth_list = list()
         for data in data_list:
@@ -56,6 +50,3 @@ SCP로 EC2에 tsv 파일을 직접 업로드한 후에 명령어를 실행해 �
             raise CommandError(f"bulk_create 중 오류가 발생했습니다: {e}")
 
         self.stdout.write(self.style.SUCCESS(f"Booth 모델에 데이터 {len(instances)}개를 삽입했습니다."))
-
-        os.remove(file_path)
-        self.stdout.write("tsv 파일을 삭제했습니다.")

--- a/booths/management/commands/insertbooth.py
+++ b/booths/management/commands/insertbooth.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
             except Location.DoesNotExist:
                 raise CommandError(
                     f"Location 데이터가 올바르지 않습니다. "
-                    f"(building={data['location.building']}, number={data['location.number']})"
+                    f"(building={data['location_building']}, number={data['location_number']})"
                 )
 
             booth = Booth(

--- a/booths/management/commands/insertbooth.py
+++ b/booths/management/commands/insertbooth.py
@@ -1,23 +1,17 @@
-import argparse
 import csv
+import sys
+import io
 from django.core.management.base import BaseCommand, CommandError
 from booths.models import Booth
 from searchs.models import Location
 
 class Command(BaseCommand):
     help = """Booth 모델에 여러 개의 레코드를 삽입합니다.
-로컬에 파일을 준비한 뒤, 파일이 존재하는 곳에서 명령어를 실행해 주세요."""
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            '--file',
-            type=argparse.FileType('r'),
-            required=True,
-            help="tsv 파일 경로를 입력해 주세요.",
-        )
+사용법: 로컬에 파일을 준비한 뒤, 파일이 위치한 곳에서 명령어를 실행해 주세요.
+python manage.py insertbooth < booth.tsv"""
 
     def handle(self, *args, **options):
-        file = options['file']
+        file = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
         reader = csv.DictReader(file, delimiter='\t')
         data_list = list(reader)
 

--- a/booths/management/commands/insertbooth.py
+++ b/booths/management/commands/insertbooth.py
@@ -11,9 +11,14 @@ class Command(BaseCommand):
 python manage.py insertbooth < booth.tsv"""
 
     def handle(self, *args, **options):
-        file = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
-        reader = csv.DictReader(file, delimiter='\t')
-        data_list = list(reader)
+        try:
+            file = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+            reader = csv.DictReader(file, delimiter='\t')
+            data_list = list(reader)
+        except UnicodeDecodeError as e:
+            raise CommandError(f"파일 인코딩 오류입니다. UTF-8 형식인지 확인해 주세요: {e}")
+        except Exception as e:
+            raise CommandError(f"파일을 읽는 중 오류가 발생했습니다: {e}")
 
         booth_list = list()
         for data in data_list:

--- a/shows/management/commands/insertshow.py
+++ b/shows/management/commands/insertshow.py
@@ -21,19 +21,16 @@ python manage.py insertshow < show.tsv"""
         except Exception as e:
             raise CommandError(f"파일을 읽는 중 오류가 발생했습니다: {e}")
 
+        try:
+            location = Location.objects.get(
+                building=LocationChoices.STUDENT_UNION,
+                number__isnull=True,
+            )
+        except Location.DoesNotExist:
+            raise CommandError("Location 데이터가 올바르지 않습니다.")
+
         show_list = list()
         for data in data_list:
-            try:
-                location = Location.objects.get(
-                    building=LocationChoices.STUDENT_UNION,
-                    number__isnull=True,
-                )
-            except Location.DoesNotExist:
-                raise CommandError(
-                    f"Location 데이터가 올바르지 않습니다. "
-                    f"(building={LocationChoices.STUDENT_UNION}, number=Null)"
-                )
-
             show = Show(
                 id=data['id'],
                 name=data['name'],

--- a/shows/management/commands/insertshow.py
+++ b/shows/management/commands/insertshow.py
@@ -1,5 +1,6 @@
-import argparse
 import csv
+import sys
+import io
 from django.core.management.base import BaseCommand, CommandError
 from utils.choices import LocationChoices
 from shows.models import Show
@@ -7,18 +8,11 @@ from searchs.models import Location
 
 class Command(BaseCommand):
     help = """Show 모델에 여러 개의 레코드를 삽입합니다.
-로컬에 파일을 준비한 뒤, 파일이 존재하는 곳에서 명령어를 실행해 주세요."""
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            '--file',
-            type=argparse.FileType('r'),
-            required=True,
-            help="tsv 파일 경로를 입력해 주세요.",
-        )
+사용법: 로컬에 파일을 준비한 뒤, 파일이 위치한 곳에서 명령어를 실행해 주세요.
+python manage.py insertshow < show.tsv"""
 
     def handle(self, *args, **options):
-        file = options['file']
+        file = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
         reader = csv.DictReader(file, delimiter='\t')
         data_list = list(reader)
 

--- a/shows/management/commands/insertshow.py
+++ b/shows/management/commands/insertshow.py
@@ -12,9 +12,14 @@ class Command(BaseCommand):
 python manage.py insertshow < show.tsv"""
 
     def handle(self, *args, **options):
-        file = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
-        reader = csv.DictReader(file, delimiter='\t')
-        data_list = list(reader)
+        try:
+            file = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+            reader = csv.DictReader(file, delimiter='\t')
+            data_list = list(reader)
+        except UnicodeDecodeError as e:
+            raise CommandError(f"파일 인코딩 오류입니다. UTF-8 형식인지 확인해 주세요: {e}")
+        except Exception as e:
+            raise CommandError(f"파일을 읽는 중 오류가 발생했습니다: {e}")
 
         show_list = list()
         for data in data_list:

--- a/shows/management/commands/insertshow.py
+++ b/shows/management/commands/insertshow.py
@@ -1,32 +1,26 @@
+import argparse
 import csv
-import os
 from django.core.management.base import BaseCommand, CommandError
-from utils.helpers import tsv_file
 from utils.choices import LocationChoices
 from shows.models import Show
 from searchs.models import Location
 
 class Command(BaseCommand):
     help = """Show 모델에 여러 개의 레코드를 삽입합니다.
-SCP로 EC2에 tsv 파일을 직접 업로드한 후에 명령어를 실행해 주세요."""
+로컬에 파일을 준비한 뒤, 파일이 존재하는 곳에서 명령어를 실행해 주세요."""
 
     def add_arguments(self, parser):
         parser.add_argument(
             '--file',
-            type=tsv_file,
+            type=argparse.FileType('r'),
             required=True,
             help="tsv 파일 경로를 입력해 주세요.",
         )
 
     def handle(self, *args, **options):
-        file_path:str = options['file']
-
-        try:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                reader = csv.DictReader(f, delimiter='\t')
-                data_list = list(reader)
-        except Exception as e:
-            raise CommandError(f"tsv 파일을 읽는 중 오류가 발생했습니다: {e}")
+        file = options['file']
+        reader = csv.DictReader(file, delimiter='\t')
+        data_list = list(reader)
 
         show_list = list()
         for data in data_list:
@@ -56,6 +50,3 @@ SCP로 EC2에 tsv 파일을 직접 업로드한 후에 명령어를 실행해 �
             raise CommandError(f"bulk_create 중 오류가 발생했습니다: {e}")
 
         self.stdout.write(self.style.SUCCESS(f"Show 모델에 데이터 {len(instances)}개를 삽입했습니다."))
-
-        os.remove(file_path)
-        self.stdout.write("tsv 파일을 삭제했습니다.")

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,5 +1,3 @@
-import argparse
-import os
 from django.utils.deconstruct import deconstructible
 from django.utils import timezone
 from rest_framework.pagination import LimitOffsetPagination
@@ -47,10 +45,3 @@ class BasePagination(LimitOffsetPagination):
         },
         status=status.HTTP_200_OK,
         )
-
-def tsv_file(value:str):
-    if not value.endswith('.tsv'):
-        raise argparse.ArgumentTypeError(f"'{value}'은 .tsv 파일이 아닙니다.")
-    if not os.path.exists(value):
-        raise argparse.ArgumentTypeError(f"{value} 파일을 찾을 수 없습니다.")
-    return value


### PR DESCRIPTION
## 🔎 What is this PR?

- #101 을 리팩토링했습니다.

## ✨ Changes

### 1. `insertbooth`, `insertshow` 명령어에서 tsv 파일을 stdin 방식으로 입력하도록 리팩토링했습니다.
- 번거롭게 서버에 파일을 직접 업로드할 필요 없이, 로컬에서 바로 파일 내용을 전송할 수 있습니다.
- 서버에 파일을 업로드하지 않는 덕분에 보안성이 향상됩니다.
- 기존에는 `--file` 인자로 파일 경로를 받았지만, 개선안은 stdin으로 파일 내용을 바로 처리합니다.

#### 명령어 사용 방법
1. `insertlocation` 명령어를 먼저 실행하여 Location 데이터를 준비합니다.
2. 구글 스프레드 시트를 tsv 형식으로 다운로드합니다.
3. tsv 파일에서 `{N/A}` 등의 빈 값이 포함된 행을 삭제합니다.
4. tsv 파일이 위치한 곳에서 명령어를 실행합니다.
   ```bash
   python manage.py insertbooth < booth.tsv
   ```
   ```bash
   python manage.py insertshow < show.tsv
   ```

### 2. 그 외 자잘한 수정사항
- `tsv_file` 헬퍼 함수 삭제: stdin으로 데이터를 입력 받기 때문에 더이상 사용하지 않음 https://github.com/EWHA-LIKELION/14th-Ewha-Festival-Back/pull/103/changes/d57189d87c432aece247946314ff1cbf53bb9e7a
- insertbooth 명령어 Location.DoesNotExist 오류 메시지 수정
  - 오타 수정 https://github.com/EWHA-LIKELION/14th-Ewha-Festival-Back/pull/103/changes/2721ff1f90e8ce89ed10abd5af457dcac87c019d
  - 몇 번째 행인지 표시 https://github.com/EWHA-LIKELION/14th-Ewha-Festival-Back/pull/103/changes/2ac51bd697975d69f38e6884242d0e52864640a6
- insertshow 명령어에서 반복하지 않아도 되는 행을 반복문 밖으로 꺼냄: Show 모델의 모든 레코드는 모두 같은 Location 레코드를 참조한다. 따라서 반복마다 다를 필요 없이 모두 동일한 location 인스턴스를 지정하면 된다. https://github.com/EWHA-LIKELION/14th-Ewha-Festival-Back/pull/103/changes/c714a9117bb743e26df17637fc75e0c286b37b41

## 📷 Result

### `insertbooth`

<img src="https://github.com/user-attachments/assets/d1c0b948-5067-4d73-a2b9-883ff77eb491" />

### `insertshow`

<img src="https://github.com/user-attachments/assets/071f7f3a-d83c-4f08-92ba-a37fd9896b23" />

DB에 잘 들어간 것도 확인했습니다.

## 💬 To. Reviewer

프론트엔드에게 빨리 넘기기 위해 코드 리뷰 생략하겠습니다.