### PR TITLE
🐛 Shows의 json_field 수정

### DIFF
--- a/shows/serializers.py
+++ b/shows/serializers.py
@@ -37,7 +37,7 @@ class ShowPatchSerializer(
             "deleted_setlist_ids",
             "deleted_notice_ids",
         )
-        json_fields = ("setlist", "category", "location", "schedule", "sns", "notice",
+        json_fields = ("setlist", "location", "schedule", "sns", "notice",
             "deleted_setlist_ids",
             "deleted_notice_ids",)
 


### PR DESCRIPTION
## 🔎 What is this PR?

- 관련 API 명세서 링크

## ✨ Changes

- 아까 sns를 수정하면서 따로 파싱이 이루어지는 `json_fields`에 괄호가 포함된 모든 컬럼을 추가했는데, 제가 booth와 shows 모두 category가 배열형식인 것으로 착각해서 shows에서 오류가 발생했습니다.
- 그래서 `shows`의 `json_fields`에서 `category`를 제거하니 에러가 해결되었습니다.

## 📷 Result


## 💬 To. Reviewer

