### PR TITLE
EC2 인스턴스에서 Docker와 Docker Compose 설치 실패 해결

### DIFF
--- a/configs/scripts/deploy.sh
+++ b/configs/scripts/deploy.sh
@@ -5,13 +5,31 @@ if ! type docker > /dev/null
 then
     echo "Not exist: docker"
     echo "Start install: docker"
+    
+    # 기존 Docker 저장소 제거
+    sudo rm -f /etc/apt/sources.list.d/docker.list
+    
+    # 시스템 패키지 업데이트
     sudo apt-get update
-    sudo apt install -y apt-transport-https ca-certificates curl software-properties-common
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key-add -
-    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
-    sudo apt update
-    apt-cache policy docker-ce
-    sudo apt install -y docker-ce
+    sudo apt install -y apt-transport-https ca-certificates curl software-properties-common gnupg lsb-release
+    
+    # Docker GPG 키 추가
+    sudo mkdir -p /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    
+    # Docker 저장소 추가
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    
+    # 패키지 리스트 업데이트
+    sudo apt-get update
+    
+    # Docker 설치
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+    
+    # Docker 서비스 시작
+    sudo systemctl start docker
+    sudo systemctl enable docker
 fi
 
 # Docker Compose 설치 여부를 확인하고, 없으면 설치한다.
@@ -23,6 +41,6 @@ then
     sudo chmod +x /usr/local/bin/docker-compose
 fi
 
-# Docker Compose로 서버를 빌드하고 실행한다. (docker-compose.prod.yml 사용)
+# Docker Compose로 서버를 빌드하고 실행한다.
 echo "Start docker-compose up: ubuntu"
 sudo docker-compose -f /home/ubuntu/srv/ubuntu/docker-compose.prod.yml up --build -d


### PR DESCRIPTION
## 문제 분석

로그를 보면 **EC2 인스턴스에서 Docker와 Docker Compose 설치 실패**가 주요 원인입니다:

### 핵심 에러:
1. **Docker GPG 키 검증 실패**
   - Docker 저장소의 서명을 확인할 수 없음 (`NO_PUBKEY 7EA0A9C3F273FCD8`)
   - Ubuntu bionic 버전의 Docker 저장소가 더 이상 지원되지 않음

2. **Docker Compose 실행 실패**
   - Docker 데몬이 실행 중이지 않아서 Docker Compose가 작동 불가
   - `FileNotFoundError: [Errno 2] No such file or directory` 에러 발생

3. **apt-key 명령 오류**
   - `sudo: 'apt-key-add': command not found` - 구버전 우분투에서 GPG 키 추가 실패

## 핵심 변경사항

- **GPG 키 처리**: 새로운 signed-by 방식으로 변경 (더 안전하고 신뢰할 수 있음)
- **Docker 서비스 시작**: `systemctl start docker` 추가로 데몬 실행 보장
- **기존 저장소 제거**: 손상된 Docker 저장소 설정 제거