### PR TITLE
docker-compose 다운로드 URL을 최신 버전으로 수정함

### DIFF
--- a/configs/scripts/deploy.sh
+++ b/configs/scripts/deploy.sh
@@ -37,7 +37,7 @@ if ! type docker-compose > /dev/null
 then
     echo "Not exist: docker-compose"
     echo "Start install: docker-compose"
-    sudo curl -L "https://github.com/docker/compose/releases/download/1.27.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     sudo chmod +x /usr/local/bin/docker-compose
 fi
 


### PR DESCRIPTION
오래된 Docker Compose 버전(1.27.3)과 현재 Docker 버전 간의 호환성 문제 해결을 위해 최신 Docker Compose v2를 설치함.