### PR TITLE
🐛 Product 이미지 삭제 무시됨 해결

### DIFF
--- a/booths/serializers.py
+++ b/booths/serializers.py
@@ -26,13 +26,6 @@ class BoothProductWriteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product
         fields = ('id', 'name', 'description', 'price', 'image', 'is_selling')
-        
-    def to_internal_value(self, data):
-        if 'image' in data and data['image'] in ['null', 'None', '', 'undefined']:
-            mutable_data = data.copy() if hasattr(data, 'copy') else data
-            mutable_data['image'] = None
-            return super().to_internal_value(mutable_data)
-        return super().to_internal_value(data)
 
 class BoothNoticeSerializer(BaseNoticeSerializer):
     class Meta(BaseNoticeSerializer.Meta):
@@ -116,10 +109,14 @@ class BoothPatchSerializer(
             else:
                 products = list(product_val) if product_val else []
 
+            null_sentinels = {'null', 'None', '', 'undefined'}
             for i, product in enumerate(products):
-                image = request.FILES.get(f'product_image_{i}')
+                key = f'product_image_{i}'
+                image = request.FILES.get(key)
                 if image:
                     product['image'] = image
+                elif data.get(key) in null_sentinels:
+                    product['image'] = None
 
             data['product'] = products
 


### PR DESCRIPTION
## 🔎 What is this PR?


## ✨ Changes

- patch에 사용되는 product 객체에는 image가 빠져 있습니다. 그러나 제 기존 로직에서는 삭제할 시에는 또 image를 포함해야 합니다. 이보단 로직 일관성 유지를 위해 product_image_0: null 형식으로 이미지를 삭제하도록 수정하였습니다.

## 📷 Result

## 💬 To. Reviewer
