### PR TITLE
공지 is_updated 오류 수정

### DIFF
--- a/utils/abstract_serializers.py
+++ b/utils/abstract_serializers.py
@@ -6,6 +6,7 @@ from typing import Optional, Type, List, Dict, Any
 from django.db import transaction
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
+from datetime import timedelta
 from rest_framework.exceptions import ValidationError
 from utils.exceptions import Conflict
 import json
@@ -50,7 +51,9 @@ class BaseNoticeSerializer(serializers.ModelSerializer):
         return time_ago(obj.created_at)
 
     def get_is_updated(self, obj):
-        return obj.updated_at != obj.created_at
+        if obj.created_at is None or obj.updated_at is None:
+            return False
+        return (obj.updated_at - obj.created_at) > timedelta(seconds=1)
 
 class BaseReviewSerializer(serializers.ModelSerializer):
     number = serializers.SerializerMethodField()


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ Changes

get_is_updated가 obj.updated_at != obj.created_at로 비교해서, 생성 시점에 auto_now_add와 auto_now가 각각 따로 now()를 호출하면 마이크로초 단위의 미세한 차이로도 같지 않게 되어 true로 나온다 합니다.
- utils/abstract_serializers.py의 get_is_updated를 수정해 아주 작은 차이(1s) 이내는 수정된 것으로 보지 않도록 했습니다. 
- 구체적 변경:
   - from datetime import timedelta 추가
   - def get_is_updated(...)를 아래처럼 변경:
      - created_at/updated_at 없음 -> False
      - (updated_at - created_at) > timedelta(seconds=1) 일 때만 True

## 📷 Result

## 💬 To. Reviewer
