### PR TITLE
이름순 정렬 수정

### DIFF
--- a/utils/filters_sorts.py
+++ b/utils/filters_sorts.py
@@ -1,4 +1,5 @@
 from django.db.models import Q, Case, When, Value, IntegerField, DateTimeField
+from django.db.models.functions import Collate, Lower
 from django.db.models.expressions import RawSQL
 from datetime import datetime, timedelta
 from django.utils.dateparse import parse_date
@@ -87,13 +88,19 @@ def base_sort(qs, sorting: str | None, *, program: str):
     if sorting == "name":
         qs = qs.annotate(
             name_priority = Case(
-                When(name__regex=r'^[가-힣]', then=Value(0)),
+                When(name__regex=r'^[가-힣ㄱ-ㅎㅏ-ㅣ]', then=Value(0)),
                 When(name__regex=r'^[A-Za-z]', then=Value(1)),
                 default=Value(2),
                 output_field=IntegerField(),
             )
         )
-        return qs.order_by("name_priority", "name", "id")
+        #print(qs.query)
+        return qs.order_by(
+            "name_priority", 
+            Collate(Lower("name"), "ko-KR-x-icu"),
+            "name", 
+            "id"
+        )
     
     # 부스 default - 번호순
     if program == "booth" and sorting in ("number", ""):

--- a/utils/filters_sorts.py
+++ b/utils/filters_sorts.py
@@ -65,14 +65,15 @@ def base_filter(qs, params, *, program: str):
 BOOTH_BUILDING_PRIORITY = [
     LocationChoices.HUMAN_ECOLOGY_BUILDING,
     LocationChoices.STUDENT_UNION,
-    LocationChoices.HAK_GWAN,
     LocationChoices.EWHA_POSCO_BUILDING,
-    LocationChoices.SENTENNIAL_MUSEUM,
+    LocationChoices.HAK_GWAN,
     LocationChoices.WELCH_RYANG_AUDITORIUM,
-    LocationChoices.HYUUT_GIL,
+    LocationChoices.GRASS_GROUND,
     LocationChoices.EDUCATION_BUILDING,
-    LocationChoices.EWHA_SHINSEGAE_BUILDING,
+    LocationChoices.HYUUT_GIL,
+    LocationChoices.SENTENNIAL_MUSEUM,
     LocationChoices.SPORT_TRACK,
+    LocationChoices.EWHA_SHINSEGAE_BUILDING,
 ]
 
 def base_sort(qs, sorting: str | None, *, program: str):

--- a/utils/filters_sorts.py
+++ b/utils/filters_sorts.py
@@ -80,6 +80,16 @@ def base_sort(qs, sorting: str | None, *, program: str):
     
     # 이름순
     if sorting == "name":
+        if program == "show":
+            qs = qs.annotate(
+                name_priority = Case(
+                    When(name__regex=r'^[가-힣]', then=Value(0)),
+                    When(name__regex=r'^[A-Za-z]', then=Value(1)),
+                    default=Value(2),
+                    output_field=IntegerField(),
+                )
+            )
+            return qs.order_by("name_priority", "name", "id")
         return qs.order_by("name", "id")
     
     # 부스 default - 번호순

--- a/utils/filters_sorts.py
+++ b/utils/filters_sorts.py
@@ -42,18 +42,22 @@ def base_filter(qs, params, *, program: str):
         start = datetime.combine(d, datetime.min.time())
         end = start + timedelta(days=1)
 
-        qs = qs.annotate(
-            has_overlap_date=RawSQL(
-                """
-                EXISTS(
-                    SELECT 1
-                    FROM unnest(schedule) AS r
-                    WHERE r && tstzrange(%s, %s, '[)')
+        if program == "booth":
+            qs = qs.annotate(
+                has_overlap_date=RawSQL(
+                    """
+                    EXISTS(
+                        SELECT 1
+                        FROM unnest(schedule) AS r
+                        WHERE r && tstzrange(%s, %s, '[)')
+                    )
+                    """,
+                    [start, end],
                 )
-                """,
-                [start, end],
-            )
-        ).filter(has_overlap_date=True)
+            ).filter(has_overlap_date=True)
+            
+        elif program == "show":
+            qs = qs.filter(schedule__overlap=(start, end))
     
     return qs
 

--- a/utils/filters_sorts.py
+++ b/utils/filters_sorts.py
@@ -80,17 +80,15 @@ def base_sort(qs, sorting: str | None, *, program: str):
     
     # 이름순
     if sorting == "name":
-        if program == "show":
-            qs = qs.annotate(
-                name_priority = Case(
-                    When(name__regex=r'^[가-힣]', then=Value(0)),
-                    When(name__regex=r'^[A-Za-z]', then=Value(1)),
-                    default=Value(2),
-                    output_field=IntegerField(),
-                )
+        qs = qs.annotate(
+            name_priority = Case(
+                When(name__regex=r'^[가-힣]', then=Value(0)),
+                When(name__regex=r'^[A-Za-z]', then=Value(1)),
+                default=Value(2),
+                output_field=IntegerField(),
             )
-            return qs.order_by("name_priority", "name", "id")
-        return qs.order_by("name", "id")
+        )
+        return qs.order_by("name_priority", "name", "id")
     
     # 부스 default - 번호순
     if program == "booth" and sorting in ("number", ""):


### PR DESCRIPTION
## 🔎 What is this PR?

[공연 전체 조회](https://www.notion.so/likelion-ewha/2f38432fec7480758947cc27b7a555ee?v=2f38432fec74810db582000c96a7fd82&p=30a8432fec74805aaccff2b0df8d11c4&pm=s)

## ✨ Changes

- 이름순 정렬시 (?sorting=name) 한글 -> 영어 -> 특수기호(아스키코드순) 순서로 정렬되도록 수정했습니다.
- 부스 정렬, 공연 정렬 모두 같은 로직을 사용합니다.
- `schedule` 필드 수정에 따른 요일 필터링 오류를 수정했습니다.

## 📷 Result
**이름순 정렬**
<img width="1127" height="286" alt="image" src="https://github.com/user-attachments/assets/778c95ab-8242-4fb7-a03e-50c32ba91b47" />
<img width="1125" height="40" alt="image" src="https://github.com/user-attachments/assets/33d0afc4-4a10-472a-8cce-abff77caf84c" />
<img width="1120" height="40" alt="image" src="https://github.com/user-attachments/assets/9ef5a46f-4e98-492d-b48e-cfe7e0d30820" />
<img width="1132" height="41" alt="image" src="https://github.com/user-attachments/assets/04b26e45-9eaa-45b6-9770-8b63a6192e16" />
<img width="1129" height="38" alt="image" src="https://github.com/user-attachments/assets/700b5911-891a-41f3-b490-9beb427f36d9" />

**요일 필터 적용**
<img width="1136" height="809" alt="image" src="https://github.com/user-attachments/assets/84927069-6216-4d4e-be4d-544d1a410ed1" />


## 💬 To. Reviewer

**한글 가나다 -> 영어 abc -> 특수문자** 순으로 정렬되는데, 이는 장고의 기본 `order_by("name")`이랑 아예 반대가 되는 순서여서, '한국인'이 생각하는 정렬을 간단하게 구현하기 위해서 `Collate`를 사용했습니다. 다만 이 Collation이 PostgreSQL 및 서버 환경에 따라 지원 여부가 달라질 수 있는데, 제가 찾아본 바로는 최신 버전은 거의 다 제가 사용한 icu(`ko-KR-x-icu`)를 지원한다고 합니다. 
혹시나 배포 서버에 반영했는데 오류가 나거나 정렬이 제대로 되지 않는다면 db 콘솔에서 
```
SELECT collname
FROM pg_collation
WHERE collname LIKE '%ko-KR-x-icu%'
```
으로 해당 icu를 지원하는지 확인한 후 없다면 설치를 하면 됩니다. 
그리고 제가 개발하다가 착각을 해서 정렬 기본순이 대문자 -> 소문자인데 기디분들께 반대로 알려드려서 Lower로 소문자 -> 대문자 정렬이 되게 만들었습니다.
