### PR TITLE
🐛 이미지 업데이트 관련 abstract_serializer 수정

### DIFF
--- a/utils/abstract_serializers.py
+++ b/utils/abstract_serializers.py
@@ -377,18 +377,36 @@ class BasePatchSerializer(JsonParsingMixin, serializers.ModelSerializer):
 
         with transaction.atomic():
             root_fields = self.get_root_update_fields(validated_data)
-            root_fields[version_field] = now
+
+            file_fields = {}
+            db_fields = {}
+            for field_name, value in root_fields.items():
+                try:
+                    model_field = self.Meta.model._meta.get_field(field_name)  # type: ignore
+                    if hasattr(model_field, 'upload_to'):
+                        file_fields[field_name] = value
+                        continue
+                except Exception:
+                    pass
+                db_fields[field_name] = value
+
+            db_fields[version_field] = now
 
             updated_rows = self.Meta.model.objects.filter(  # type: ignore
                 pk=instance.pk,
                 **{version_field: client_version},
-            ).update(**root_fields)
+            ).update(**db_fields)
 
             if updated_rows == 0:
                 latest = self._get_latest_version(instance.pk)
                 raise Conflict(server_updated_at=latest)
 
-            instance = self.Meta.model.objects.get(pk=instance.pk)  
+            instance = self.Meta.model.objects.get(pk=instance.pk)
+
+            if file_fields:
+                for field_name, value in file_fields.items():
+                    setattr(instance, field_name, value)
+                instance.save(update_fields=list(file_fields.keys()))
 
             touched = False
             for spec in specs:


### PR DESCRIPTION
## 🔎 What is this PR?
부스/공연 수정


## ✨ Changes
### 원인
BasePatchSerializer.update()는 낙관적 잠금을 위해 QuerySet.update()로 필드를 갱신하도록 설계되어 있습니다. 일반 필드에서는 잘 동작하지만, ImageField / FileField에는 이 방식을 사용하면 안 된다는 점을 설계 당시 인지하지 못했습니다.
QuerySet.update()는 SQL UPDATE를 직접 실행하기 때문에 Model.save()를 거치지 않습니다. 이로 인해 FileField.pre_save()가 호출되지 않아 다음 두 가지 문제가 발생했습니다.

- 업로드된 파일이 스토리지에 저장되지 않음
- DB에 올바른 경로(thumbnail/booth/.../photo.jpg) 대신 원본 파일명(photo.jpg)만 저장되어 URL이 깨짐

### 수정 내용
update() 내에서 root_fields를 두 그룹으로 분리했습니다.

db_fields ) upload_to가 없는 일반 필드 → 기존과 동일하게 queryset.update() 처리
file_fields ) upload_to가 있는 ImageField / FileField → instance.save(update_fields=[...]) 로 별도 저장하여 pre_save() 훅이 정상 호출되도록 수정

## 📷 Result
<img width="1328" height="557" alt="image" src="https://github.com/user-attachments/assets/c910d413-c763-4fc6-89ff-248808e54cd0" />

<img width="1373" height="716" alt="image" src="https://github.com/user-attachments/assets/cf970459-e0e7-4117-8566-1411d15e6f12" />



## 💬 To. Reviewer

