### PR TITLE
공지/메뉴/세트리스트 정렬 수정

### DIFF
--- a/booths/serializers.py
+++ b/booths/serializers.py
@@ -54,7 +54,7 @@ class BoothDetailSerializer(BaseProgramDetailSerializer):
         fields = BaseProgramDetailSerializer.Meta.fields + ('host', 'product')
 
     def get_product(self, obj):
-        products = obj.product.all()
+        products = obj.product.order_by('id')
         return BoothProductSerializer(products, many=True).data
 
     def get_notice_serializer(self): return BoothNoticeSerializer

--- a/booths/views.py
+++ b/booths/views.py
@@ -88,7 +88,7 @@ class BoothNoticeView(APIView):
         notices = (
             BoothNotice.objects
             .filter(booth_id=pk)
-            .order_by('-created_at')
+            .order_by('-created_at', '-id')
         )
 
         serializer = BoothNoticeSerializer(

--- a/shows/serializers.py
+++ b/shows/serializers.py
@@ -93,7 +93,10 @@ class ShowListSerializer(BaseProgramListSerializer):
 
 class ShowDetailSerializer(BaseProgramDetailSerializer):
     is_ongoing = serializers.CharField(read_only=True)
-    setlist = ShowSetlistSerializer(many=True)
+    setlist = serializers.SerializerMethodField()
+
+    def get_setlist(self, obj):
+        return ShowSetlistSerializer(obj.setlist.order_by('id'), many=True).data
 
     class Meta(BaseProgramDetailSerializer.Meta):
         model = Show

--- a/shows/views.py
+++ b/shows/views.py
@@ -92,7 +92,7 @@ class ShowNoticeView(APIView):
         notices = (
             ShowNotice.objects
             .filter(show_id=pk)
-            .order_by('-created_at')
+            .order_by('-created_at', '-id')
         )
 
         serializer = ShowNoticeSerializer(


### PR DESCRIPTION
## 🔎 What is this PR?

- [API 명세서/부스 상세 조회](https://www.notion.so/likelion-ewha/2f68432fec748040bb1ed45ec174a416)
- [API 명세서/공연 상세 조회](https://www.notion.so/likelion-ewha/2f68432fec74807f9181d44913f0737a)

## ✨ Changes

공지는 -id를 2차 정렬로 추가해 타임스탬프가 동일해도 나중에 삽입된 항목(높은 id)이 먼저 오게 했고, product/setlist는 order_by('id')로 항상 등록 순서(오래된 순)를 보장합니다.

기존 오류: 공지 등록 시 한꺼번에 등록했을 때와 하나씩 등록했을 때 정렬이 달라짐.
기획 수정: 메뉴, 세트리스트는 오래된순으로 수정됨.

공지
- 최신 정렬 (유지)
- 하나씩 등록하면 최신순으로 보이도록 (유지)
- 한꺼번에 여러 개 등록한 것 최신순으로 보이도록

메뉴
- 오래된 순 정렬
- 하나씩 등록하면 오래된순으로 보이도록
- 한꺼번에 여러 개 등록한 것 오래된순으로 보이드록

세트리스트
- 오래된 순 정렬
- 하나씩 등록하면 오래된순으로 보이도록
- 한꺼번에 여러 개 등록한 것 오래된순으로 보이도록

## 📷 Result

- 공지 (한꺼번에 등록해도 최신순으로)
<img width="324" height="400" alt="image" src="https://github.com/user-attachments/assets/e8e04a5a-e335-4852-bd3d-7f3c803ea935" />

- 메뉴 (오래된순)
<img width="521" height="287" alt="image" src="https://github.com/user-attachments/assets/ba285a1c-cc2c-4488-8e78-cd44722b3175" />

- 세트리스트 (오래된순)
<img width="218" height="183" alt="image" src="https://github.com/user-attachments/assets/f5b4e633-05db-4448-ae81-ace7c8dacb08" />


## 💬 To. Reviewer
