### PR TITLE
부스/공연 수정 API 트랜잭션 로직 리팩토링

### DIFF
--- a/booths/serializers.py
+++ b/booths/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 import json
 from .models import Booth, Product, BoothReview, BoothNotice, BoothScrap
-from utils.abstract_serializers import BaseProgramListSerializer, BaseProgramDetailSerializer, BaseNoticeSerializer, BaseReviewSerializer, BaseScrapSerializer, ProgramPatchMixin, NestedCollectionPatchMixin, BaseNoticeWriteSerializer, BasePatchSerializer, CollectionPatchSpec
+from utils.abstract_serializers import BaseProgramListSerializer, BaseProgramDetailSerializer, BaseNoticeSerializer, BaseReviewSerializer, BaseScrapSerializer, ProgramPatchMixin, BaseNoticeWriteSerializer, BasePatchSerializer, CollectionPatchSpec
 from utils.serializer_fields import ScheduleWriteField
 
 class BoothListSerializer(BaseProgramListSerializer):
@@ -68,7 +68,6 @@ class BoothDetailSerializer(BaseProgramDetailSerializer):
 class BoothPatchSerializer(
     BasePatchSerializer,
     ProgramPatchMixin,
-    NestedCollectionPatchMixin,
     serializers.ModelSerializer,
 ):
     is_ongoing = serializers.BooleanField(source='ongoing')

--- a/booths/views.py
+++ b/booths/views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from .models import Booth, BoothNotice, BoothScrap
 from .serializers import BoothListSerializer, BoothDetailSerializer, BoothNoticeSerializer, BoothPatchSerializer, BoothScrapSerializer
+from utils.patch_service import ProgramPatchService
 from utils.filters_sorts import filter_and_sort
 from utils.helpers import BasePagination
 
@@ -73,9 +74,9 @@ class BoothDetailView(APIView):
             context={"request": request},
         )
         patch_serializer.is_valid(raise_exception=True)
-        patch_serializer.save()
+        ProgramPatchService().update(patch_serializer, booth)
 
-        booth = self.get_object(pk)  
+        booth = self.get_object(pk)
         read_serializer = BoothDetailSerializer(booth, context={"request": request})
         return Response(read_serializer.data, status=status.HTTP_200_OK)
 

--- a/configs/settings/base.py
+++ b/configs/settings/base.py
@@ -161,7 +161,6 @@ SIMPLE_JWT = {
     'TOKEN_USER_CLASS': AUTH_USER_MODEL,
 }
 
-
 # S3
 AWS_ACCESS_KEY_ID = env('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = env('AWS_SECRET_ACCESS_KEY')
@@ -187,8 +186,6 @@ STORAGES = {
     },
 }
 
-
 # Media files
-
 MEDIA_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')

--- a/shows/serializers.py
+++ b/shows/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from .models import Show, Setlist, ShowNotice, ShowReview, ShowScrap
-from utils.abstract_serializers import ProgramPatchMixin, NestedCollectionPatchMixin, BaseNoticeWriteSerializer, BasePatchSerializer, CollectionPatchSpec, BaseProgramListSerializer, BaseProgramDetailSerializer, BaseNoticeSerializer, BaseReviewSerializer, BaseScrapSerializer
+from utils.abstract_serializers import ProgramPatchMixin, BaseNoticeWriteSerializer, BasePatchSerializer, CollectionPatchSpec, BaseProgramListSerializer, BaseProgramDetailSerializer, BaseNoticeSerializer, BaseReviewSerializer, BaseScrapSerializer
 from utils.serializer_fields import ScheduleWriteField
 
 class SetlistWriteSerializer(serializers.ModelSerializer):
@@ -17,9 +17,8 @@ class ShowNoticeWriteSerializer(BaseNoticeWriteSerializer):
         model = ShowNotice
         
 class ShowPatchSerializer(
-    BasePatchSerializer,           
-    ProgramPatchMixin,              
-    NestedCollectionPatchMixin,
+    BasePatchSerializer,
+    ProgramPatchMixin,
     serializers.ModelSerializer,
 ):
     setlist = SetlistWriteSerializer(many=True, required=False)

--- a/shows/views.py
+++ b/shows/views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from .models import Show, ShowNotice, ShowScrap
 from .serializers import ShowListSerializer, ShowDetailSerializer, ShowNoticeSerializer, ShowPatchSerializer, ShowScrapSerializer
+from utils.patch_service import ProgramPatchService
 from utils.filters_sorts import filter_and_sort
 from utils.helpers import BasePagination
 
@@ -73,7 +74,7 @@ class ShowDetailView(APIView):
             context={"request": request},
         )
         patch_serializer.is_valid(raise_exception=True)
-        patch_serializer.save()
+        ProgramPatchService().update(patch_serializer, show)
 
         show = self.get_object(pk)
 

--- a/utils/abstract_serializers.py
+++ b/utils/abstract_serializers.py
@@ -1,14 +1,12 @@
 from rest_framework import serializers
 from utils.helpers import time_ago
 from .location_serializers import LocationSerializer
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, Type, List, Dict, Any
-from django.db import transaction
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from datetime import timedelta
 from rest_framework.exceptions import ValidationError
-from utils.exceptions import Conflict
 import json
 
 class JsonParsingMixin:
@@ -227,74 +225,6 @@ class ProgramPatchMixin:
         return {k: v for k, v in validated_data.items() if k in self.program_fields}
     
     
-class NestedCollectionPatchMixin:
-    def patch_collection(
-        self,
-        *,
-        instance,
-        items_data,
-        deleted_ids,
-        manager_name: str,      # 예: "product", "booth_notice", "show_notice", "setlist"
-        model_cls,              # Product / BoothNotice / ShowNotice / Setlist
-        parent_fk_name: str,    # "booth" / "show"
-        serializer_class,
-        items_field_name: str,   # 예: "product" / "setlist"
-        deleted_field_name: str  # 예: "deleted_product_ids" / "deleted_notice_ids" ...
-    ) -> bool:
-        """
-        items_data: list[dict] or None
-        deleted_ids: list[int] or None
-        return: touched(bool)
-        """
-        touched = False
-        manager = getattr(instance, manager_name, None)
-        if manager is None:
-            raise NotImplementedError(f"Invalid manager_name: {manager_name}")
-
-        # upsert
-        if items_data is not None:
-            for item in items_data:
-                item_id = item.get("id")
-
-                if item_id is None:
-                    s = serializer_class(data=item, context=self.context)
-                    try:
-                        s.is_valid(raise_exception=True)
-                    except serializers.ValidationError as e:
-                        raise serializers.ValidationError({items_field_name: e.detail})
-
-                    
-                    payload = dict(s.validated_data)
-                    payload[parent_fk_name] = instance
-                    model_cls.objects.create(**payload)
-                    touched = True
-                    continue
-
-                obj = manager.filter(id=item_id).first()
-                if obj is None:
-                    raise serializers.ValidationError({
-                        items_field_name: [f"{item_id} is not in this resource."]
-                    })
-                
-                s = serializer_class(obj, data=item, partial=True, context=self.context)
-                s.is_valid(raise_exception=True)
-                s.save()
-                touched = True
-
-        # delete
-        if deleted_ids is not None:
-            ids = set(deleted_ids)
-            found = set(manager.filter(id__in=ids).values_list("id", flat=True))
-            missing = ids - found
-            if missing:
-                raise serializers.ValidationError({
-                    deleted_field_name: [f"Invalid ids: {sorted(missing)}"]
-                })
-            manager.filter(id__in=ids).delete()
-            touched = True
-
-        return touched
-    
 @dataclass(frozen=True)
 class CollectionPatchSpec:
     items_field_name: str          # payload 키: "product" / "notice" / "playlist"
@@ -360,76 +290,6 @@ class BasePatchSerializer(JsonParsingMixin, serializers.ModelSerializer):
         vf = self.get_version_field_name()
         return self.Meta.model.objects.filter(pk=pk).values_list(vf, flat=True).first()  # type: ignore
 
-    def update(self, instance, validated_data):
-        specs = self.get_collection_specs()
-
-        nested_map = {}
-        deleted_map = {}
-
-        for spec in specs:
-            nested_map[spec.items_field_name] = validated_data.pop(spec.items_field_name, None)
-            if spec.deleted_field_name:
-                deleted_map[spec.deleted_field_name] = validated_data.pop(spec.deleted_field_name, None)
-
-        client_version = self._get_client_version()
-        now = timezone.now()
-        version_field = self.get_version_field_name()
-
-        with transaction.atomic():
-            root_fields = self.get_root_update_fields(validated_data)
-
-            file_fields = {}
-            db_fields = {}
-            for field_name, value in root_fields.items():
-                try:
-                    model_field = self.Meta.model._meta.get_field(field_name)  # type: ignore
-                    if hasattr(model_field, 'upload_to'):
-                        file_fields[field_name] = value
-                        continue
-                except Exception:
-                    pass
-                db_fields[field_name] = value
-
-            db_fields[version_field] = now
-
-            updated_rows = self.Meta.model.objects.filter(  # type: ignore
-                pk=instance.pk,
-                **{version_field: client_version},
-            ).update(**db_fields)
-
-            if updated_rows == 0:
-                latest = self._get_latest_version(instance.pk)
-                raise Conflict(server_updated_at=latest)
-
-            instance = self.Meta.model.objects.get(pk=instance.pk)
-
-            if file_fields:
-                for field_name, value in file_fields.items():
-                    setattr(instance, field_name, value)
-                instance.save(update_fields=list(file_fields.keys()))
-
-            touched = False
-            for spec in specs:
-                items_data = nested_map.get(spec.items_field_name)
-                deleted_ids = deleted_map.get(spec.deleted_field_name) if spec.deleted_field_name else None
-
-                touched |= self.patch_collection(
-                    instance=instance,
-                    items_data=items_data,
-                    deleted_ids=deleted_ids,
-                    manager_name=spec.manager_name,
-                    model_cls=spec.model_cls,
-                    parent_fk_name=spec.parent_fk_name,
-                    serializer_class=spec.serializer_class,
-                    items_field_name=spec.items_field_name,
-                    deleted_field_name=spec.deleted_field_name or "",
-                )
-
-            if touched and self.should_bump_updated_at():
-                self.Meta.model.objects.filter(pk=instance.pk).update(**{version_field: timezone.now()})
-                instance.refresh_from_db(fields=[version_field])
-
-        return instance
 
 
 class BaseManagedProgramSerializer(serializers.ModelSerializer):

--- a/utils/patch_service.py
+++ b/utils/patch_service.py
@@ -1,0 +1,141 @@
+from django.db import transaction
+from django.utils import timezone
+from rest_framework import serializers
+from utils.exceptions import Conflict
+
+
+class ProgramPatchService:
+
+    def _patch_collection(
+        self,
+        *,
+        context,
+        instance,
+        items_data,
+        deleted_ids,
+        manager_name,
+        model_cls,
+        parent_fk_name,
+        serializer_class,
+        items_field_name,
+        deleted_field_name,
+    ):
+        touched = False
+        manager = getattr(instance, manager_name, None)
+        if manager is None:
+            raise NotImplementedError(f"Invalid manager_name: {manager_name}")
+
+        if items_data is not None:
+            for item in items_data:
+                item_id = item.get("id")
+
+                if item_id is None:
+                    s = serializer_class(data=item, context=context)
+                    try:
+                        s.is_valid(raise_exception=True)
+                    except serializers.ValidationError as e:
+                        raise serializers.ValidationError({items_field_name: e.detail})
+
+                    payload = dict(s.validated_data)
+                    payload[parent_fk_name] = instance
+                    model_cls.objects.create(**payload)
+                    touched = True
+                    continue
+
+                obj = manager.filter(id=item_id).first()
+                if obj is None:
+                    raise serializers.ValidationError({
+                        items_field_name: [f"{item_id} is not in this resource."]
+                    })
+
+                s = serializer_class(obj, data=item, partial=True, context=context)
+                s.is_valid(raise_exception=True)
+                s.save()
+                touched = True
+
+        if deleted_ids is not None:
+            ids = set(deleted_ids)
+            found = set(manager.filter(id__in=ids).values_list("id", flat=True))
+            missing = ids - found
+            if missing:
+                raise serializers.ValidationError({
+                    deleted_field_name: [f"Invalid ids: {sorted(missing)}"]
+                })
+            manager.filter(id__in=ids).delete()
+            touched = True
+
+        return touched
+
+    def update(self, serializer, instance):
+        validated_data = dict(serializer.validated_data)
+        specs = serializer.get_collection_specs()
+        context = serializer.context
+
+        nested_map = {}
+        deleted_map = {}
+        for spec in specs:
+            nested_map[spec.items_field_name] = validated_data.pop(spec.items_field_name, None)
+            if spec.deleted_field_name:
+                deleted_map[spec.deleted_field_name] = validated_data.pop(spec.deleted_field_name, None)
+
+        client_version = serializer._get_client_version()
+        now = timezone.now()
+        version_field = serializer.get_version_field_name()
+        model_cls = serializer.Meta.model
+
+        with transaction.atomic():
+            root_fields = serializer.get_root_update_fields(validated_data)
+
+            file_fields = {}
+            db_fields = {}
+            for field_name, value in root_fields.items():
+                try:
+                    model_field = model_cls._meta.get_field(field_name)
+                    if hasattr(model_field, 'upload_to'):
+                        file_fields[field_name] = value
+                        continue
+                except Exception:
+                    pass
+                db_fields[field_name] = value
+
+            db_fields[version_field] = now
+
+            updated_rows = model_cls.objects.filter(
+                pk=instance.pk,
+                **{version_field: client_version},
+            ).update(**db_fields)
+
+            if updated_rows == 0:
+                latest = serializer._get_latest_version(instance.pk)
+                raise Conflict(server_updated_at=latest)
+
+            instance = model_cls.objects.get(pk=instance.pk)
+
+            if file_fields:
+                for field_name, value in file_fields.items():
+                    setattr(instance, field_name, value)
+                instance.save(update_fields=list(file_fields.keys()))
+
+            touched = False
+            for spec in specs:
+                items_data = nested_map.get(spec.items_field_name)
+                deleted_ids = deleted_map.get(spec.deleted_field_name) if spec.deleted_field_name else None
+
+                touched |= self._patch_collection(
+                    context=context,
+                    instance=instance,
+                    items_data=items_data,
+                    deleted_ids=deleted_ids,
+                    manager_name=spec.manager_name,
+                    model_cls=spec.model_cls,
+                    parent_fk_name=spec.parent_fk_name,
+                    serializer_class=spec.serializer_class,
+                    items_field_name=spec.items_field_name,
+                    deleted_field_name=spec.deleted_field_name or "",
+                )
+
+            if touched and serializer.should_bump_updated_at():
+                model_cls.objects.filter(pk=instance.pk).update(**{version_field: timezone.now()})
+                instance.refresh_from_db(fields=[version_field])
+
+        return instance


### PR DESCRIPTION
## 🔎 What is this PR?


## ✨ Changes
- patch_service 파일을 생성해 DB 트랜잭션 내용을 처리하도록 하고 이를 VIEW에서 직접 호출하도록 변경했습니다.

| 파일 | 변경 내용 |
|---|---|
| `utils/patch_service.py` | 신규 — `ProgramPatchService` 클래스. `_patch_collection()`과 `update()`로 트랜잭션/DB 쓰기 로직 전담 |
| `utils/abstract_serializers.py` | `NestedCollectionPatchMixin` 전체 삭제, `BasePatchSerializer.update()` 삭제, `transaction`·`Conflict` import 제거 |
| `booths/serializers.py` | `NestedCollectionPatchMixin` import 및 상속 제거 |
| `shows/serializers.py` | `NestedCollectionPatchMixin` import 및 상속 제거 |
| `booths/views.py` | `patch_serializer.save()` → `ProgramPatchService().update(patch_serializer, booth)` |
| `shows/views.py` | `patch_serializer.save()` → `ProgramPatchService().update(patch_serializer, show)` |


## 📷 Result
<img width="1247" height="867" alt="image" src="https://github.com/user-attachments/assets/ff454c66-5e42-49fb-a141-39570cfcdf49" />
<img width="1327" height="732" alt="image" src="https://github.com/user-attachments/assets/82c22b06-a17b-4d4f-b88e-1e725df6bdae" />
<img width="1305" height="838" alt="image" src="https://github.com/user-attachments/assets/ec89cfa8-7f17-4269-b2f3-708829114430" />

## 💬 To. Reviewer

