### PR TITLE
요일 중복 필터링 수정

### DIFF
--- a/utils/filters_sorts.py
+++ b/utils/filters_sorts.py
@@ -37,28 +37,29 @@ def base_filter(qs, params, *, program: str):
 
     # 요일
     qs = qs.filter(q)
+    dates = [parse_date(d) for d in params.getlist("date") if parse_date(d)]
 
-    d = parse_date(params.get("date") or "")
-    if d:
-        start = datetime.combine(d, datetime.min.time())
-        end = start + timedelta(days=1)
-
+    if dates:
         if program == "booth":
+            range_conditions = " OR ".join(
+                "EXISTS(SELECT 1 FROM unnest(schedule) AS r WHERE r && tstzrange(%s, %s, '[)'))"
+                for _ in dates
+            )
+            sql_params = [p for d in dates for p in (
+                datetime.combine(d, datetime.min.time()),
+                datetime.combine(d, datetime.min.time()) + timedelta(days=1),
+            )]
             qs = qs.annotate(
-                has_overlap_date=RawSQL(
-                    """
-                    EXISTS(
-                        SELECT 1
-                        FROM unnest(schedule) AS r
-                        WHERE r && tstzrange(%s, %s, '[)')
-                    )
-                    """,
-                    [start, end],
-                )
+                has_overlap_date=RawSQL(range_conditions, sql_params)
             ).filter(has_overlap_date=True)
             
         elif program == "show":
-            qs = qs.filter(schedule__overlap=(start, end))
+            date_q = Q()
+            for d in dates:
+                start = datetime.combine(d, datetime.min.time())
+                end = start + timedelta(days=1)
+                date_q |= Q(schedule__overlap=(start, end))
+            qs = qs.filter(date_q)
     
     return qs
 


### PR DESCRIPTION
## 🔎 What is this PR?

부스, 공연 전체 조회 / 검색 / 스크랩 필터링에서 사용되는 요일 필터링 중복 선택을 가능하게 했습니다.

## ✨ Changes

booth와 show 모델의 schedule 필드가 달라졌기 때문에 각각 다른 로직으로 처리했습니다. 공통적으로 date를 getlist로 받을 수 있게 처리한 후
- booth는 기존과 동일하게 RawSQL 사용
- show는 Q객체 사용

## 📷 Result

<img width="1020" height="247" alt="image" src="https://github.com/user-attachments/assets/128f67e6-3e8c-4251-88c5-429bdac8ac38" />
<img width="1012" height="242" alt="image" src="https://github.com/user-attachments/assets/fa8a9a14-a19f-4ac9-8d55-8ed40b8aaee2" />

## 💬 To. Reviewer
