### PR TITLE
FileSizeValidator 추가

### DIFF
--- a/utils/validators.py
+++ b/utils/validators.py
@@ -1,0 +1,15 @@
+from django.core.exceptions import ValidationError
+from django.utils.deconstruct import deconstructible
+
+@deconstructible
+class FileSizeValidator:
+    def __init__(self, min_size_MB:int|None=None, max_size_MB:int|None=None):
+        self.min_size_MB = min_size_MB
+        self.max_size_MB = max_size_MB
+
+    def __call__(self, value):
+        if (self.min_size_MB) and (value.size < self.min_size_MB *1024*1024):
+            raise ValidationError(f"파일 '{value.name}'의 용량이 최소 용량 {self.min_size_MB}MB를 미만합니다.")
+
+        if (self.max_size_MB) and (value.size > self.max_size_MB *1024*1024):
+            raise ValidationError(f"파일 '{value.name}'의 용량이 최대 용량 {self.max_size_MB}MB를 초과합니다.")


### PR DESCRIPTION
## 🔎 What is this PR?

- https://github.com/EWHA-LIKELION/Likelion-Ewha-Website-Back/pull/46
- [Notion/API 명세서/부스 수정 API](https://www.notion.so/likelion-ewha/2f78432fec74807cbb47c899eb947ff7)
- [Notion/API 명세서/공연 수정 API](https://www.notion.so/likelion-ewha/2f78432fec7480128535dd77c92c514c)

## ✨ Changes

이미지 파일 업로드 로직에서 사용할 수 있는 FileSizeValidator를 추가했습니다.
파일 크기와 지정한 값을 비교하여, 허용 범위를 벗어났을 경우 ValidationError를 raise합니다.

### 예시
```python
from rest_framework import serializers
from utils.validators import FileSizeValidator

class CreateSerializer(serializers.Serializer):
    image = serializers.ImageField(
        validators=[
            FileSizeValidator(min_size_MB=0, max_size_MB=20),
        ],
    )
```

## 📷 Result

## 💬 To. Reviewer
