### PR TITLE
Gunicorn 연결 시간 증대

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,7 +5,13 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.prod
-    command: gunicorn configs.wsgi:application --bind 0.0.0.0:8000
+    command: gunicorn configs.wsgi:application \
+      --bind 0.0.0.0:8000 \
+      --workers 3 \
+      --keep-alive 75 \
+      --timeout 120 \
+      --worker-class sync \
+      --access-logfile -
     expose:
       - 8000
     entrypoint:


### PR DESCRIPTION
## 🔎 What is this PR?

- Cold Start 이슈 해결

## ✨ Changes

- Cold Start 원인: ALB는 60초 동안 연결을 유지하려 하지만, Gunicorn은 기본값인 2초 후 연결을 끊어버립니다. 그러면 다음 요청 때 ALB가 죽은 연결로 요청을 보내고, 실패 후 재연결하는 과정에서 10초 가까운 지연이 발생합니다.
- Gunicorn의 `--keep-alive`를 ALB idle timeout(60초)보다 크게 설정함으로써 Cold Start 이슈를 해결했습니다.

## 📷 Result

## 💬 To. Reviewer
