### PR TITLE
Gunicorn 커맨드 문법을 yaml 배열로 수정

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,8 @@ services:
       - --workers=3
       - --keep-alive=75
       - --timeout=120
+      - --worker-class=sync
+      - --access-logfile=-
     expose:
       - 8000
     entrypoint:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,13 +5,13 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.prod
-    command: gunicorn configs.wsgi:application \
-      --bind 0.0.0.0:8000 \
-      --workers 3 \
-      --keep-alive 75 \
-      --timeout 120 \
-      --worker-class sync \
-      --access-logfile -
+    command:
+      - gunicorn
+      - configs.wsgi:application
+      - --bind=0.0.0.0:8000
+      - --workers=3
+      - --keep-alive=75
+      - --timeout=120
     expose:
       - 8000
     entrypoint:


### PR DESCRIPTION
502 원인: `\`이 문자열 그대로 들어가서, 파라미터가 모두 무시됐음.

```yaml
# ❌ 이렇게 하면 \가 문자 그대로 들어감
command: gunicorn configs.wsgi:application \
  --bind 0.0.0.0:8000 \
  --workers 3
```
```yaml
# ✅ yaml 배열로 써야 안전
command:
  - gunicorn
  - configs.wsgi:application
  - --bind=0.0.0.0:8000
  - --workers=3
  - --keep-alive=75
  - --timeout=120
```