### PR TITLE
검색어 띄어쓰기 완화 및 리팩토링

### DIFF
--- a/searchs/views.py
+++ b/searchs/views.py
@@ -1,5 +1,5 @@
-from django.db.models import Q, Count, Value, CharField, Case, When
-from django.db.models.functions import Concat, Cast
+from django.db.models import Q, Count, Value, CharField, Case, When, F
+from django.db.models.functions import Concat, Cast, Replace
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -15,10 +15,13 @@ from utils.helpers import BasePagination
 from searchs.services import record_search, get_popular_searches
 
 def search(*, request, booths_qs, shows_qs):
+    import re
     q = (request.query_params.get("q") or "").strip()
-    q_normalize = q.replace(" ", "")
+    q_normalize = re.sub(r'\s+', '', q)
+    qs_no_space = Replace(F('name'), Value(' '), Value(''))
 
     booths_qs = booths_qs.annotate(
+        name_no_space=qs_no_space,
     building_label=Case(
         When(location__building=LocationChoices.GRASS_GROUND, then=Value("잔디광장")),
         When(location__building=LocationChoices.SENTENNIAL_MUSEUM, then=Value("박물관")),
@@ -43,10 +46,10 @@ def search(*, request, booths_qs, shows_qs):
     )
 
     booth_q = (
-        Q(name__icontains=q_normalize) |
-        Q(product__name__icontains=q_normalize) |
-        Q(location__building__icontains=q_normalize) |
-        Q(full_location__icontains=q_normalize)
+        Q(name__icontains=q) | Q(name__icontains=q_normalize) | Q(name_no_space__icontains=q_normalize) |
+        Q(product__name__icontains=q) | Q(product__name__icontains=q_normalize) |
+        Q(location__building__icontains=q) | Q(location__building__icontains=q_normalize) |
+        Q(full_location__icontains=q) | Q(full_location__icontains=q_normalize)
     )
 
     if q_normalize.isdigit():
@@ -59,9 +62,11 @@ def search(*, request, booths_qs, shows_qs):
         .distinct()
     )
 
-    show_q = Q(name__icontains=q_normalize)
+    show_q = (
+        Q(name__icontains=q) | Q(name__icontains=q_normalize) | Q(name_no_space__icontains=q_normalize)
+    )
     shows = (
-        shows_qs
+        shows_qs.annotate(name_no_space=qs_no_space)
         .filter(show_q)
         .annotate(scraps_count=Count("show_scrap", distinct=True))
         .distinct()

--- a/searchs/views.py
+++ b/searchs/views.py
@@ -1,3 +1,5 @@
+import re
+
 from django.db.models import Q, Count, Value, CharField, Case, When, F
 from django.db.models.functions import Concat, Cast, Replace
 from rest_framework import status
@@ -15,7 +17,6 @@ from utils.helpers import BasePagination
 from searchs.services import record_search, get_popular_searches
 
 def search(*, request, booths_qs, shows_qs):
-    import re
     q = (request.query_params.get("q") or "").strip()
     q_normalize = re.sub(r'\s+', '', q)
     qs_no_space = Replace(F('name'), Value(' '), Value(''))


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ Changes

<img width="534" height="527" alt="image" src="https://github.com/user-attachments/assets/68d1d467-9d17-4d6f-852d-17297eb2dec5" />

- 제가 검색 개발 & 리팩토링하면서 "띄어쓰기가 있는 데이터"를 고려하지 않고 수정했어서 다시 포함시켰습니다. 현재는 위처럼 띄어쓰기가 있는 데이터는 제대로 검색이 되지 않습니다..
- 그리고 원래 로직은 검색어 `q`에서만 띄어쓰기를 제거하고 검색이 가능하도록 되어있어서 공백을 제거한 `q`가 데이터와 완전히 일치해야 검색이 되었는데요, 
    - 예: 데이터가 "나는 사자" 라면 "나는 사자"는 검색이 되지만 "나는사자"로 검색했을 때 검색이 안 됨.
    데이터 자체의 공백도 제거하여 인식하도록 수정했습니다. 이제 "나 는 사 자", "나는사자", "나    는사자" 모두 검색됩니다.
- 띄어쓰기 기준을 완화했습니다. 원래는 기본 공백 " "만 제거하면서 검색이 가능하게 했는데 "\n", "\t" 등등의 공백을 포함해도 검색이 가능하도록 수정했습니다.
 
## 📷 Result

<img width="571" height="369" alt="image" src="https://github.com/user-attachments/assets/1996c2b8-2879-4b84-9a97-d9e8516886bc" />
<img width="525" height="302" alt="image" src="https://github.com/user-attachments/assets/fb288a87-a218-4fad-ac87-15610e53ce64" />
<img width="575" height="299" alt="image" src="https://github.com/user-attachments/assets/bdb2a0ff-bd3c-4e0e-96b5-359f703eb667" />

## 💬 To. Reviewer

- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
