### PR TITLE
스냅샷 스케줄러 정각 기준 수정

### DIFF
--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -1,5 +1,5 @@
 from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.triggers.interval import IntervalTrigger
+from apscheduler.triggers.cron import CronTrigger
 from django_apscheduler.jobstores import DjangoJobStore
 import logging
 
@@ -17,7 +17,7 @@ def start():
     scheduler.add_jobstore(DjangoJobStore(), "default")
     scheduler.add_job(
         update_snapshot,
-        trigger=IntervalTrigger(hours=1),
+        trigger=CronTrigger(minute=0),
         id="update_search_snapshot",
         replace_existing=True,
     )


### PR DESCRIPTION
## 🔎 What is this PR?

- 관련 API 명세서 링크

## ✨ Changes

현재 인기검색어 스냅샷이 정각이 아닌 서버 시작 시점을 기준으로 1시간마다 갱신되고 있어 화면상에서 업데이트 시각이 실제 시각보다 늦게 표시되는 문제를 해결하기 위해 스케줄러를 정각 실행으로 변경하였습니다. 

## 📷 Result

- 스크린샷, 시연 영상 등

## 💬 To. Reviewer

- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
