### PR TITLE
무중단 배포

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -7,7 +7,7 @@ server {
 
     location / {
         proxy_pass http://configs;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_redirect off;

--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -1,5 +1,5 @@
 upstream configs {
-    server web:8000;
+    server web_blue:8000;
 }
 
 server {
@@ -9,6 +9,7 @@ server {
         proxy_pass http://configs;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_redirect off;
     }
 

--- a/configs/scripts/deploy.sh
+++ b/configs/scripts/deploy.sh
@@ -41,6 +41,70 @@ then
     sudo chmod +x /usr/local/bin/docker-compose
 fi
 
-# Docker Compose로 서버를 빌드하고 실행한다.
-echo "Start docker-compose up: ubuntu"
-sudo docker-compose -f /home/ubuntu/srv/ubuntu/docker-compose.prod.yml up --build -d
+# -------------------------------------------------------
+# Blue/Green 무중단 배포
+# -------------------------------------------------------
+WORKDIR=/home/ubuntu/srv/ubuntu
+COMPOSE="sudo docker-compose -f $WORKDIR/docker-compose.prod.yml"
+
+# 현재 어느 쪽이 떠 있는지 판별
+BLUE_RUNNING=$(sudo docker ps --format '{{.Names}}' | grep -w web_blue || true)
+GREEN_RUNNING=$(sudo docker ps --format '{{.Names}}' | grep -w web_green || true)
+
+# 최초 배포 (아무것도 안 떠 있음)
+if [ -z "$BLUE_RUNNING" ] && [ -z "$GREEN_RUNNING" ]; then
+    echo "▶ 최초 배포: web_blue + nginx 시작"
+    $COMPOSE up -d --build web_blue nginx
+    echo "✅ 최초 배포 완료 — web_blue 서비스 중"
+    exit 0
+fi
+
+# active/next 결정
+if [ -n "$BLUE_RUNNING" ]; then
+    NEXT_CONTAINER="web_green"
+    NEXT_PORT="8001"
+    NEXT_SERVER="web_green:8001"
+    OLD_CONTAINER="web_blue"
+else
+    NEXT_CONTAINER="web_blue"
+    NEXT_PORT="8000"
+    NEXT_SERVER="web_blue:8000"
+    OLD_CONTAINER="web_green"
+fi
+
+echo "▶ 전환: $OLD_CONTAINER → $NEXT_CONTAINER"
+
+# 1. 새 컨테이너 빌드 및 시작
+$COMPOSE up -d --build $NEXT_CONTAINER
+
+# 2. 헬스체크 (최대 45초 대기)
+echo "▶ 헬스체크 시작..."
+for i in $(seq 1 15); do
+    if sudo docker exec $NEXT_CONTAINER curl -sf http://localhost:$NEXT_PORT/health/ > /dev/null 2>&1; then
+        echo "✅ 헬스체크 통과"
+        break
+    fi
+    if [ $i -eq 15 ]; then
+        echo "❌ 헬스체크 실패 — $NEXT_CONTAINER 종료, 기존 유지"
+        $COMPOSE stop $NEXT_CONTAINER
+        exit 1
+    fi
+    echo "   대기 중... ($i/15)"
+    sleep 3
+done
+
+# 3. nginx upstream 전환
+echo "▶ nginx upstream → $NEXT_SERVER"
+sudo docker exec nginx sed -i \
+    "s|server web_.*:.*;|server $NEXT_SERVER;|" \
+    /etc/nginx/conf.d/nginx.conf
+
+# 4. nginx 무중단 reload
+sudo docker exec nginx nginx -s reload
+echo "▶ nginx reload 완료"
+
+# 5. 구 컨테이너 종료
+echo "▶ $OLD_CONTAINER 종료"
+$COMPOSE stop $OLD_CONTAINER
+
+echo "✅ 배포 완료 — $NEXT_CONTAINER 서비스 중"

--- a/configs/urls.py
+++ b/configs/urls.py
@@ -1,9 +1,14 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.http import JsonResponse
 from django.urls import path, include
 
+def health_check(request):
+    return JsonResponse({"status": "ok"})
+
 urlpatterns = [
+    path("health/", health_check),
     path('admin/', admin.site.urls),
     path('accounts/', include('accounts.urls')),
     path('searchs/', include('searchs.urls')),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,7 +1,8 @@
 version: "3"
+
 services:
-  web:
-    container_name: web
+  web_blue:
+    container_name: web_blue
     build:
       context: ./
       dockerfile: Dockerfile.prod
@@ -24,10 +25,36 @@ services:
       - media:/home/app/web/media
     env_file:
       - .env
+
+  web_green:
+    container_name: web_green
+    build:
+      context: ./
+      dockerfile: Dockerfile.prod
+    command:
+      - gunicorn
+      - configs.wsgi:application
+      - --bind=0.0.0.0:8000
+      - --workers=3
+      - --keep-alive=75
+      - --timeout=120
+      - --worker-class=sync
+      - --access-logfile=-
+    expose:
+      - 8001
+    entrypoint:
+      - sh
+      - configs/docker/entrypoint.prod.sh
+    volumes:
+      - static:/home/app/web/static
+      - media:/home/app/web/media
+    env_file:
+      - .env
+
   nginx:
     container_name: nginx
     depends_on:
-      - web
+      - web_blue
     build: ./configs/nginx
     ports:
       - "80:80"
@@ -36,6 +63,7 @@ services:
       - media:/home/app/web/media
     environment:
       TZ: "Asia/Seoul"
+
 volumes:
   static:
   media:


### PR DESCRIPTION
## 🔎 What is this PR?

MA 구조의 백엔드 서버를 Blue-Green 방식으로 배포합니다.

## ✨ Changes

기존에는 컨테이너를 중지하고, 삭제하고, 볼륨도 삭제하고, 이미지도 삭제하고, 프로젝트 디렉토리도 삭제하는 등 모든 걸 정리한 후에 새로 처음부터 배포하는 방식으로 진행하여 다운타임이 꽤 발생했었습니다.

Blue-Green 배포 방식으로 수정하여, 다운타임 없이 무중단 배포할 수 있도록 개선했습니다. 기존 컨테이너를 유지한 채로 새로운 컨테이너를 띄우고, 새로운 컨테이너가 준비 완료되면 전환한 뒤 기존 컨테이너를 종료하는 방식입니다.

1. `docker-compose.prod.yml`에서 `web_blue`와 `web_green` 컨테이너를 정의했습니다.
2. Nginx 설정에서 초기값을 blue로 지정했습니다.
3. Django에서 헬스체크 엔드포인트를 추가했습니다.
4. 배포 스크립트 `configs/scripts/deploy.sh`에서 현재 활성화된 컨테이너를 판별하고, 새로운 컨테이너를 띄워서 교체하고, 구 컨테이너는 종료합니다.

## 📷 Result

## 💬 To. Reviewer