### PR TITLE
Gunicorn 로그 폴더 권한 부여

### DIFF
--- a/configs/docker/entrypoint.prod.sh
+++ b/configs/docker/entrypoint.prod.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 mkdir -p /var/log/gunicorn
+chown -R app:app /var/log/gunicorn
 
 python manage.py collectstatic --no-input
 python manage.py makemigrations


### PR DESCRIPTION
## 원인

```
Error: '/var/log/gunicorn/error.log' isn't writable [PermissionError(13, 'Permission denied')]
```

`entrypoint.prod.sh`에서 `mkdir -p /var/log/gunicorn`을 root로 만들고, 이후 `USER app`으로 전환된 상태에서 gunicorn이 그 폴더에 쓰려니 권한이 없었습니다.

## 해결

권한 부여하는 코드를 추가했습니다.