### PR TITLE
logs 볼륨을 호스트 경로 대신 named volume으로 변경

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - static:/home/app/web/static
       - media:/home/app/web/media
-      - ./logs/gunicorn-blue:/var/log/gunicorn
+      - gunicorn_blue_log:/var/log/gunicorn
     env_file:
       - .env
 
@@ -39,7 +39,7 @@ services:
     volumes:
       - static:/home/app/web/static
       - media:/home/app/web/media
-      - ./logs/gunicorn-green:/var/log/gunicorn
+      - gunicorn_green_log:/var/log/gunicorn
     env_file:
       - .env
 
@@ -53,10 +53,13 @@ services:
     volumes:
       - static:/home/app/web/static
       - media:/home/app/web/media
-      - ./logs/nginx:/var/log/nginx
+      - nginx_log:/var/log/nginx
     environment:
       TZ: "Asia/Seoul"
 
 volumes:
   static:
   media:
+  gunicorn_blue_log:
+  gunicorn_green_log:
+  nginx_log:


### PR DESCRIPTION
## 원인

```
rsync: [generator] delete_file: rmdir(logs/gunicorn-green) failed: Permission denied (13)
rsync error: some files/attrs were not transferred (code 23)
```

이전 배포에서 컨테이너가 `logs/gunicorn-green/` 디렉토리를 root 권한으로 생성했습니다. rsync는 `--delete` 옵션으로 해당 폴더를 지우려 하는데, ubuntu 유저로 실행 중인 rsync는 권한이 없어서 실패합니다.

## 해결

logs 볼륨을 호스트 경로 대신 named volume으로 변경했습니다.