### PR TITLE
Nginx: user directive 위치 오류 &  Gunicorn: chown 권한 없음

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -47,6 +47,7 @@ ENV APP_HOME=/home/app/web
 RUN mkdir $APP_HOME
 RUN mkdir $APP_HOME/static
 RUN mkdir $APP_HOME/media
+RUN mkdir -p /var/log/gunicorn
 WORKDIR $APP_HOME
 
 # Install dependencies
@@ -72,6 +73,7 @@ COPY . $APP_HOME
 
 # Chown all the files to the app user
 RUN chown -R app:app $APP_HOME
+RUN chown -R app:app /var/log/gunicorn
 
 # Change to the app user
 USER app

--- a/configs/docker/entrypoint.prod.sh
+++ b/configs/docker/entrypoint.prod.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-mkdir -p /var/log/gunicorn
-chown -R app:app /var/log/gunicorn
-
 python manage.py collectstatic --no-input
 python manage.py makemigrations
 python manage.py migrate

--- a/configs/nginx/Dockerfile
+++ b/configs/nginx/Dockerfile
@@ -1,5 +1,4 @@
 FROM nginx:1.19.0-alpine
 RUN rm /etc/nginx/conf.d/default.conf
-COPY nginx.conf /etc/nginx/conf.d
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
# 1. Nginx: `user` directive 위치 오류

## 원인

`configs/nginx/Dockerfile`을 보면:
```dockerfile
COPY nginx.conf /etc/nginx/conf.d   # ← 여기가 문제
COPY nginx.conf /etc/nginx/nginx.conf
```
실수로 이전 코드를 삭제하지 않았습니다.

## 해결

`nginx.conf`를 `conf.d/`에 복사하는 줄을 삭제했습니다.

# 2. Gunicorn: `chown` 권한 없음

## 원인

chown 권한이 없었습니다.

## 해결

- chown 코드를 추가했습니다.
- 겸사겸사 Dockerfile로 코드를 옮기는 리팩토링했습니다. 폴더 만드는 코드끼리, chown 코드끼리 모았습니다.