### PR TITLE
사전식 정렬 후 숫자 정렬 추가

### DIFF
--- a/utils/querysets.py
+++ b/utils/querysets.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from django.db import models
 from django.db.models import Q, Count, Value, Case, When, F, CharField, IntegerField, DateTimeField
-from django.db.models.functions import Concat, Cast, Replace, Collate, Lower
+from django.db.models.functions import Concat, Cast, Replace, Collate, Coalesce
 from django.db.models.expressions import RawSQL
 from django.utils.dateparse import parse_date
 from .choices import LocationChoices
@@ -108,12 +108,27 @@ def base_sort(qs, sorting: str | None, *, program: str):
                 When(name__regex=r'^[A-Za-z]', then=Value(1)),
                 default=Value(2),
                 output_field=IntegerField(),
-            )
+            ),
+            name_number=Coalesce(
+                Cast(
+                    RawSQL(
+                        "NULLIF(regexp_replace(name, '[^0-9]', '', 'g'), '')",
+                        ()
+                    ),
+                    output_field=IntegerField()
+                ),
+                Value(0),
+            ),
+            name_text=RawSQL(
+                "regexp_replace(name, '[0-9]', '', 'g')",
+                (),
+                output_field=CharField(),
+            ),
         )
         return qs.order_by(
             "name_priority", 
-            Collate(Lower("name"), "ko-KR-x-icu"),
-            "name", 
+            Collate("name_text", "ko-KR-x-icu"),
+            "name_number", 
             "id"
         )
     


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ Changes

이름순 정렬 수정할 때 "한글 사전식 정렬"만 신경쓰느라 숫자도 전부 사전식으로 정렬되도록 구현했어서 플리마켓 10이 플리마켓 5보다 먼저 정렬되는 문제가 생겼습니다.
- '텍스트 + 숫자' 인 데이터에서 텍스트가 같을 때 숫자가 정렬되도록 수정했습니다.

## 📷 Result

<img width="1086" height="737" alt="image" src="https://github.com/user-attachments/assets/28f53045-d2ee-4a6e-b8bb-e6e3f4db48bd" />


## 💬 To. Reviewer

일단 저희 데이터 상황에서 안정적으로 돌아가도록 텍스트 + 숫자 구조인 경우에 텍스트를 사전식으로 정렬하고 숫자를 정렬하도록 수정했는데, 조금 비효율적이긴 합니다. 이번 부스의 경우에는 적용되는 데이터가 없지만, 만약에 부스명 중간중간에 숫자가 포함되어 있으면(멋4프100) 제대로 정렬이 되지 않거든요.. 토큰 단위로 구현해야 하는데, 현재 페이지네이션도 사용하기 때문에 파이썬 자체로 natural 정렬은 사용하기 위험하고, 지금처럼 db 레벨에서 쿼리셋 정렬로 안전하고 확실하게 하려면 사전식 정렬용 필드를 추가로 만들어야 될 것 같습니다. 그렇게되면 수정폭이 많이 커져서(모델 수정해야 함) 일단 현재 데이터셋 기준으로는 작동하도록 수정했습니다.

요약하자면, 현재 우리 상황에서 작동은 잘 하지만 효율적이고 정석적인 방법은 아닙니다! 현재 시점에서 모델 수정하는게 조금 부담이 돼서 고민이 되네요. 일단 반영하고 리팩토링 하거나 이번에는 이렇게만 놔두고 인수인계 때 언급하면 좋을 것 같습니다.