### PR TITLE
스케줄러 중복 키 오류 수정

### DIFF
--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -8,18 +8,23 @@ logger = logging.getLogger(__name__)
 def start():
     from searchs.services import update_snapshot
     from django.db import connection
-    
+
     if "django_apscheduler_djangojob" not in connection.introspection.table_names():
         logger.warning("django_apscheduler table not found, skipping scheduler start")
-        return 
-    
+        return
+
     scheduler = BackgroundScheduler()
     scheduler.add_jobstore(DjangoJobStore(), "default")
-    scheduler.add_job(
-        update_snapshot,
-        trigger=CronTrigger(minute=0),
-        id="update_search_snapshot",
-        replace_existing=True,
-    )
+    try:
+        scheduler.add_job(
+            update_snapshot,
+            trigger=CronTrigger(minute=0),
+            id="update_search_snapshot",
+            replace_existing=True,
+        )
+    except Exception as e:
+        # 멀티 워커 환경에서 다른 워커가 먼저 등록한 경우 중복 키 오류가 발생할 수 있음
+        logger.warning("Scheduler job registration failed (likely duplicate from another worker): %s", e)
+        return
     scheduler.start()
     logger.info("scheduler started")

--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -23,8 +23,10 @@ def start():
             replace_existing=True,
         )
     except Exception as e:
-        # 멀티 워커 환경에서 다른 워커가 먼저 등록한 경우 중복 키 오류가 발생할 수 있음
-        logger.warning("Scheduler job registration failed (likely duplicate from another worker): %s", e)
-        return
+        if "duplicate key" in str(e).lower() or "unique constraint" in str(e).lower():
+            # 멀티 워커 환경에서 다른 워커가 먼저 등록한 경우 중복 키 오류가 발생할 수 있음
+            logger.warning("Scheduler job already registered by another worker, skipping: %s", e)
+            return
+        raise
     scheduler.start()
     logger.info("scheduler started")


### PR DESCRIPTION
## 🔎 What is this PR?

- 관련 API 명세서 링크

## ✨ Changes

gunicorn 멀티 워커 환경에서 서버 시작 시 모든 워커가 AppConfig.ready()를 통해 동시에 스케줄러 job을 등록하려다 race condition이 발생했습니다.

`replace_existing=True` 옵션이 있어도 두 워커가 동시에 "job 없음"을 확인한 뒤 동시에 INSERT를 시도하면 `duplicate key value violates unique constraint "django_apscheduler_djangojob_pkey"` 에러가 발생합니다.

이 에러로 인해 현재 부스 수정 로직이 제대로 실행되지 않고 있어 `scheduler.add_job()` 호출을 `try/except`로 감싸 다른 워커가 이미 job을 등록한 경우 예외를 잡아 warning 로그만 출력하고 duplicate ID를 등록하지 않도록 처리했습니다.

## 📷 Result

```
>>> from utils.scheduler import start
>>> start()
>>> start()
>>> 
>>> from django.db import connection
>>> print(DjangoJob.objects.all())
<QuerySet [<DjangoJob: update_search_snapshot (next run at: 5월 20, 2026, 2:00 오후)>]>
```
job이 중복 호출되지 않은 것을 확인함.

## 💬 To. Reviewer

- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
