### PR TITLE
캐싱 추가: 부스/공연 검색, 스크랩 목록 조회

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from django.http import HttpRequest
 from django.db.models import Count, F
 from django.db import IntegrityError
@@ -17,6 +18,8 @@ from urllib.parse import urlencode
 from .serializers import MyDataSerializer, PermissionSerializer
 from .services import PermissionService
 
+from utils.constants import Cachekey
+from utils.helpers import get_user_id, calc_params_hash
 from booths.models import Booth, BoothScrap
 from shows.models import Show, ShowScrap
 from searchs.views import search
@@ -217,6 +220,17 @@ class MyScrapView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, format=None):
+        cache_key = Cachekey.SCRAP_LIST.format(
+            user_id=get_user_id(request.user),
+            params_hash=calc_params_hash(request.query_params)
+        )
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return Response(
+                status=status.HTTP_200_OK,
+                data=cached
+            )
+
         booths_qs = (
             Booth.objects.select_related("location")
             .prefetch_related("product")
@@ -231,6 +245,9 @@ class MyScrapView(APIView):
             booths_qs=booths_qs,
             shows_qs=shows_qs,
         )
+
+        cache.set(cache_key, result, 60*3)
+
         return Response(
             result,
             status=status.HTTP_200_OK,

--- a/booths/views.py
+++ b/booths/views.py
@@ -165,6 +165,7 @@ class BoothScrapView(APIView):
             )
 
         serializer = BoothScrapSerializer(scrap, context={"request": request})
+
         cache.delete_pattern(Cachekey.BOOTH_LIST.format(user_id=request.user.id, params_hash="*"))
         cache.delete_pattern(Cachekey.BOOTH_DETAIL.format(user_id=request.user.id, booth_id=pk))
 

--- a/booths/views.py
+++ b/booths/views.py
@@ -127,6 +127,7 @@ class BoothDetailView(APIView):
         cache.delete_pattern(Cachekey.BOOTH_LIST.format(user_id="*", params_hash="*"))
         cache.delete_pattern(Cachekey.BOOTH_DETAIL.format(user_id="*", booth_id=pk))
         cache.delete_pattern(Cachekey.SEARCH_LIST.format(user_id="*", params_hash="*"))
+        cache.delete_pattern(Cachekey.SCRAP_LIST.format(user_id="*", params_hash="*"))
 
         return Response(read_serializer.data, status=status.HTTP_200_OK)
 
@@ -170,6 +171,7 @@ class BoothScrapView(APIView):
         cache.delete_pattern(Cachekey.BOOTH_LIST.format(user_id=request.user.id, params_hash="*"))
         cache.delete_pattern(Cachekey.BOOTH_DETAIL.format(user_id=request.user.id, booth_id=pk))
         cache.delete_pattern(Cachekey.SEARCH_LIST.format(user_id=request.user.id, params_hash="*"))
+        cache.delete_pattern(Cachekey.SCRAP_LIST.format(user_id=request.user.id, params_hash="*"))
 
         return Response(
             {"scrapped": True,

--- a/booths/views.py
+++ b/booths/views.py
@@ -124,7 +124,7 @@ class BoothDetailView(APIView):
         booth = self.get_object(request, pk)
         read_serializer = BoothDetailSerializer(booth, context={"request": request})
 
-        cache.delete_pattern("booth_list:*")
+        cache.delete_pattern(Cachekey.BOOTH_LIST.format(user_id="*", params_hash="*"))
         cache.delete_pattern(Cachekey.BOOTH_DETAIL.format(user_id="*", booth_id=pk))
 
         return Response(read_serializer.data, status=status.HTTP_200_OK)

--- a/booths/views.py
+++ b/booths/views.py
@@ -126,6 +126,7 @@ class BoothDetailView(APIView):
 
         cache.delete_pattern(Cachekey.BOOTH_LIST.format(user_id="*", params_hash="*"))
         cache.delete_pattern(Cachekey.BOOTH_DETAIL.format(user_id="*", booth_id=pk))
+        cache.delete_pattern(Cachekey.SEARCH_LIST.format(user_id="*", params_hash="*"))
 
         return Response(read_serializer.data, status=status.HTTP_200_OK)
 
@@ -168,6 +169,7 @@ class BoothScrapView(APIView):
 
         cache.delete_pattern(Cachekey.BOOTH_LIST.format(user_id=request.user.id, params_hash="*"))
         cache.delete_pattern(Cachekey.BOOTH_DETAIL.format(user_id=request.user.id, booth_id=pk))
+        cache.delete_pattern(Cachekey.SEARCH_LIST.format(user_id=request.user.id, params_hash="*"))
 
         return Response(
             {"scrapped": True,

--- a/searchs/views.py
+++ b/searchs/views.py
@@ -1,5 +1,6 @@
 import re
 
+from django.core.cache import cache
 from django.db.models import Q
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -10,7 +11,8 @@ from booths.models import Booth
 from shows.models import Show
 from booths.serializers import BoothListSerializer
 from shows.serializers import ShowListSerializer
-from utils.helpers import BasePagination
+from utils.constants import Cachekey
+from utils.helpers import BasePagination, get_user_id, calc_params_hash
 from searchs.services import record_search, get_popular_searches
 
 def search(*, request, booths_qs, shows_qs):
@@ -90,6 +92,17 @@ class SearchView(APIView):
         return [IsAuthenticated()]
 
     def get(self, request, format=None):
+        cache_key = Cachekey.SEARCH_LIST.format(
+            user_id=get_user_id(request.user),
+            params_hash=calc_params_hash(request.query_params)
+        )
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return Response(
+                status=status.HTTP_200_OK,
+                data=cached
+            )
+
         booths_qs = (
             Booth.objects.select_related("location")
             .prefetch_related("product")
@@ -105,6 +118,9 @@ class SearchView(APIView):
         q = (request.query_params.get("q") or "").strip()
         if q and (result["booths"]["counts"] > 0 or result["shows"]["counts"] > 0):
             record_search(q)
+
+        cache.set(cache_key, result, 60*3)
+
         return Response(
             result,
             status=status.HTTP_200_OK,

--- a/shows/views.py
+++ b/shows/views.py
@@ -130,6 +130,7 @@ class ShowDetailView(APIView):
 
         cache.delete_pattern(Cachekey.SHOW_LIST.format(user_id="*", params_hash="*"))
         cache.delete_pattern(Cachekey.SHOW_DETAIL.format(user_id="*", show_id=pk))
+        cache.delete_pattern(Cachekey.SEARCH_LIST.format(user_id="*", params_hash="*"))
 
         return Response(read_serializer.data, status=status.HTTP_200_OK)
 
@@ -172,6 +173,7 @@ class ShowScrapView(APIView):
 
         cache.delete_pattern(Cachekey.SHOW_LIST.format(user_id=request.user.id, params_hash="*"))
         cache.delete_pattern(Cachekey.SHOW_DETAIL.format(user_id=request.user.id, show_id=pk))
+        cache.delete_pattern(Cachekey.SEARCH_LIST.format(user_id=request.user.id, params_hash="*"))
 
         return Response(
             {"scrapped": True,

--- a/shows/views.py
+++ b/shows/views.py
@@ -128,7 +128,7 @@ class ShowDetailView(APIView):
             context={"request": request},
         )
 
-        cache.delete_pattern("show_list:*")
+        cache.delete_pattern(Cachekey.SHOW_LIST.format(user_id="*", params_hash="*"))
         cache.delete_pattern(Cachekey.SHOW_DETAIL.format(user_id="*", show_id=pk))
 
         return Response(read_serializer.data, status=status.HTTP_200_OK)

--- a/shows/views.py
+++ b/shows/views.py
@@ -169,6 +169,7 @@ class ShowScrapView(APIView):
             )
 
         serializer = ShowScrapSerializer(scrap, context={"request": request})
+
         cache.delete_pattern(Cachekey.SHOW_LIST.format(user_id=request.user.id, params_hash="*"))
         cache.delete_pattern(Cachekey.SHOW_DETAIL.format(user_id=request.user.id, show_id=pk))
 

--- a/shows/views.py
+++ b/shows/views.py
@@ -131,6 +131,7 @@ class ShowDetailView(APIView):
         cache.delete_pattern(Cachekey.SHOW_LIST.format(user_id="*", params_hash="*"))
         cache.delete_pattern(Cachekey.SHOW_DETAIL.format(user_id="*", show_id=pk))
         cache.delete_pattern(Cachekey.SEARCH_LIST.format(user_id="*", params_hash="*"))
+        cache.delete_pattern(Cachekey.SCRAP_LIST.format(user_id="*", params_hash="*"))
 
         return Response(read_serializer.data, status=status.HTTP_200_OK)
 
@@ -174,6 +175,7 @@ class ShowScrapView(APIView):
         cache.delete_pattern(Cachekey.SHOW_LIST.format(user_id=request.user.id, params_hash="*"))
         cache.delete_pattern(Cachekey.SHOW_DETAIL.format(user_id=request.user.id, show_id=pk))
         cache.delete_pattern(Cachekey.SEARCH_LIST.format(user_id=request.user.id, params_hash="*"))
+        cache.delete_pattern(Cachekey.SCRAP_LIST.format(user_id=request.user.id, params_hash="*"))
 
         return Response(
             {"scrapped": True,

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -5,6 +5,8 @@ class Cachekey(Enum):
     BOOTH_DETAIL = 'booth_detail:{user_id}:{booth_id}'
     SHOW_LIST = 'show_list:{user_id}:{params_hash}'
     SHOW_DETAIL = 'show_detail:{user_id}:{show_id}'
+    SEARCH_LIST = 'search_list:{user_id}:{params_hash}'
+    SCRAP_LIST = 'scrap_list:{user_id}:{params_hash}'
 
     def format(self, **kwargs):
         return self.value.format(**kwargs)


### PR DESCRIPTION
## 🔎 What is this PR?

- [Notion/API 명세서/부스·공연 검색 API](https://www.notion.so/likelion-ewha/2f58432fec748098b178e636a0932ded)
- [Notion/API 명세서/스크랩 목록 조회 API](https://www.notion.so/likelion-ewha/2f68432fec748002923af4eb5711a792)

## ✨ Changes

- 응답 시간 최소화 및 서버 부하 최적화를 위해 캐싱 로직을 추가했습니다.
- 부스/공연 검색 API에 캐시 저장 및 응답 로직을 추가했으며, 부스 수정 API, 공연 수정 API, 부스 스크랩 추가/취소 API, 공연 스크랩 추가/취소 API에 해당 캐시 무효화 로직을 추가했습니다.
- 스크랩 목록 조회 API에 캐시 저장 및 응답 로직을 추가했으며, 부스 수정 API, 공연 수정 API, 부스 스크랩 추가/취소 API, 공연 스크랩 추가/취소 API에 해당 캐시 무효화 로직을 추가했습니다.
- #191 에서 부스/공연 수정 시 캐시 무효화의 캐시키를 하드코딩했었는데, 캐시키 방식으로 통일했습니다.

## 📷 Result

### 부스/공연 검색 API

#### 캐시 저장

<img src="https://github.com/user-attachments/assets/933cb431-cf2c-48b9-b70c-5c2657d49319" />

#### 캐시 응답

<img src="https://github.com/user-attachments/assets/42343e5b-e01f-4c74-a26d-f4b95da20005" />

#### 캐시 무효화

카카오 로그인이 로컬에서 갑자기 code 얻는 게 안 돼서 이 테스트는 생략하겠습니다.

### 스크랩 목록 조회 API

카카오 로그인이 로컬에서 갑자기 code 얻는 게 안 돼서 이 테스트는 생략하겠습니다.

## 💬 To. Reviewer