### PR TITLE
엑세스 토큰 재발급 API 추가

### DIFF
--- a/accounts/helpers.py
+++ b/accounts/helpers.py
@@ -1,0 +1,25 @@
+from rest_framework.response import Response
+from rest_framework_simplejwt.settings import api_settings
+
+def response_jwt_cookie(status:int, detail:str, access_token:str, refresh_token:str)->Response:
+    response = Response(
+        status=status,
+        data={"detail": detail},
+    )
+    response.set_cookie(
+        key="access",
+        value=access_token,
+        max_age=int(api_settings.ACCESS_TOKEN_LIFETIME.total_seconds()),
+        secure=True,
+        httponly=True,
+        samesite="None",
+    )
+    response.set_cookie(
+        key="refresh",
+        value=refresh_token,
+        max_age=int(api_settings.REFRESH_TOKEN_LIFETIME.total_seconds()),
+        secure=True,
+        httponly=True,
+        samesite="None",
+    )
+    return response

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -8,19 +8,6 @@ from utils.choices import LocationChoices
 from booths.serializers import BoothScrapSerializer
 from shows.serializers import ShowScrapSerializer
 
-class RefreshSerializer(serializers.Serializer):
-    grant_type = serializers.ChoiceField(
-        choices=("Bearer",),
-        required=True,
-        allow_null=False,
-        allow_blank=False,
-    )
-    refresh_token = serializers.CharField(
-        required=True,
-        allow_null=False,
-        allow_blank=False,
-    )
-
 class ManagedBoothSerializer(BaseManagedProgramSerializer):
     class Meta(BaseManagedProgramSerializer.Meta):
         model = Booth

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -8,6 +8,19 @@ from utils.choices import LocationChoices
 from booths.serializers import BoothScrapSerializer
 from shows.serializers import ShowScrapSerializer
 
+class RefreshSerializer(serializers.Serializer):
+    grant_type = serializers.ChoiceField(
+        choices=("Bearer",),
+        required=True,
+        allow_null=False,
+        allow_blank=False,
+    )
+    refresh_token = serializers.CharField(
+        required=True,
+        allow_null=False,
+        allow_blank=False,
+    )
+
 class ManagedBoothSerializer(BaseManagedProgramSerializer):
     class Meta(BaseManagedProgramSerializer.Meta):
         model = Booth

--- a/accounts/services.py
+++ b/accounts/services.py
@@ -10,9 +10,6 @@ from shows.models import Show
 User = get_user_model()
 
 class JWTService:
-    def __init__(self, grant_type:str):
-        self.grant_type = grant_type
-
     def refresh(self, old_refresh_token:str)->tuple[str,str]:
         # 1. 서명·만료·blacklist 검증
         try:

--- a/accounts/services.py
+++ b/accounts/services.py
@@ -1,15 +1,44 @@
 from typing import Literal
+from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.exceptions import TokenError
 from booths.models import Booth
 from shows.models import Show
 
+User = get_user_model()
+
 class JWTService:
-    def __init__(self, grant_type):
+    def __init__(self, grant_type:str):
         self.grant_type = grant_type
 
-    def refresh(self, refresh_token):
-        pass
+    def refresh(self, old_refresh_token:str)->tuple[str,str]:
+        # 1. 서명·만료·blacklist 검증
+        try:
+            old_token = RefreshToken(old_refresh_token)  
+        except TokenError:
+            raise
+
+        # 2. 페이로드에서 user_id 추출 후 유저 조회
+        try:
+            user_id = old_token.payload.get("user_id")
+            user = User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            raise
+
+        # 3. 기존 Refresh Token blacklist 등록 (Rotation)
+        try:
+            old_token.blacklist()
+        except Exception:
+            raise
+
+        # 4. User 기반으로 새 토큰 쌍 발급
+        new_refresh = RefreshToken.for_user(user)
+        new_access_token = str(new_refresh.access_token)
+        new_refresh_token = str(new_refresh)
+
+        return new_access_token, new_refresh_token
 
 class PermissionService:
     def __init__(self, request:HttpRequest, pk:int|None=None):

--- a/accounts/services.py
+++ b/accounts/services.py
@@ -4,6 +4,13 @@ from django.shortcuts import get_object_or_404
 from booths.models import Booth
 from shows.models import Show
 
+class JWTService:
+    def __init__(self, grant_type):
+        self.grant_type = grant_type
+
+    def refresh(self, refresh_token):
+        pass
+
 class PermissionService:
     def __init__(self, request:HttpRequest, pk:int|None=None):
         self.request = request

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,3 +1,54 @@
-from django.test import TestCase
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
+from django.contrib.auth import get_user_model
 
-# Create your tests here.
+User = get_user_model()
+
+class RefreshViewTest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            kakao_id="test_kakao_123",
+            nickname="testuser",
+        )
+        self.refresh_token = RefreshToken.for_user(self.user)
+        self.url = "/accounts/refresh"
+
+    def test_200_OK(self):
+        self.client.cookies["refresh"] = str(self.refresh_token)
+        res = self.client.post(self.url)
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["detail"], "토큰을 재발급했어요.")
+        self.assertIn("access", res.cookies)
+        self.assertIn("refresh", res.cookies)
+
+    def test_401_no_refresh_token(self):
+        res = self.client.post(self.url)
+
+        self.assertEqual(res.status_code, 401)
+
+    def test_401_invalid_refresh_token(self):
+        self.client.cookies["refresh"] = "invalid.token.value"
+        res = self.client.post(self.url)
+
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(res.data["detail"], "유효하지 않은 Refresh Token이에요.")
+
+    def test_401_blacked_refresh_token(self):
+        old_token = str(self.refresh_token)
+
+        self.client.cookies["refresh"] = old_token
+        res1 = self.client.post(self.url)
+
+        self.client.cookies["refresh"] = old_token
+        res2 = self.client.post(self.url)
+
+        self.assertEqual(res2.status_code, 401)
+
+    def test_404_user_not_found(self):
+        self.user.delete()
+        self.client.cookies["refresh"] = str(self.refresh_token)
+        res = self.client.post(self.url)
+
+        self.assertEqual(res.status_code, 404)
+        self.assertEqual(res.data["detail"], "존재하지 않는 사용자예요.")

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('login/kakao/', KakaoLoginView.as_view(), name="kakao_login"),
     path("login/kakao/callback/", KakaoCallbackView.as_view(), name="kakao_callback"),
     path("logout/kakao/", KakaoLogoutView.as_view(), name="kakao_logout"),
+    path("refresh", Refresh.as_view(), name="refresh"),
     path('my-data/', MyDataView.as_view(), name='my-data'),
     path('my-scrap/', MyScrapView.as_view(), name='my-scrap'),
     path('permission/', Permission.as_view(), name='permission'),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -189,6 +189,12 @@ class KakaoLogoutView(APIView):
 
         return response
 
+class Refresh(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request:HttpRequest, format=None):
+        pass
+
 class MyDataView(APIView):
     permission_classes = [IsAuthenticated]
     

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.shortcuts import redirect 
 from django.contrib.auth import get_user_model
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from urllib.parse import urlencode
 from .serializers import RefreshSerializer, MyDataSerializer, PermissionSerializer
@@ -196,12 +197,35 @@ class Refresh(APIView):
         serializer = RefreshSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         grant_type = serializer.validated_data['grant_type']
-        refresh_token = serializer.validated_data['refresh_token']
+        old_refresh_token = serializer.validated_data['refresh_token']
 
         jwt_service = JWTService(grant_type=grant_type)
-        cookie = jwt_service.refresh(refresh_token=refresh_token)
 
-        return cookie
+        try:
+            new_access_token, new_refresh_token = jwt_service.refresh(old_refresh_token=old_refresh_token)
+        except TokenError:
+            raise Response(
+                status=status.HTTP_401_UNAUTHORIZED,
+                data={"detail": "유효하지 않은 Refresh Token이에요."},
+            )
+        except User.DoesNotExist:
+            raise Response(
+                status=status.HTTP_404_NOT_FOUND,
+                data={"detail": "존재하지 않는 사용자예요."},
+            )
+        except Exception:
+            raise Response(
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                data={"detail": "토큰 무효화 중 오류가 발생했어요."},
+            )
+
+        response = Response(
+            status=status.HTTP_200_OK,
+            data={"detail": "토큰을 재발급했어요."},
+        )
+        response.set_cookie("access", new_access_token, httponly=True, samesite="None", secure=True)
+        response.set_cookie("refresh", new_refresh_token, httponly=True, samesite="None", secure=True)
+        return response
 
 class MyDataView(APIView):
     permission_classes = [IsAuthenticated]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -15,7 +15,7 @@ from django.contrib.auth import get_user_model
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from urllib.parse import urlencode
-from .serializers import MyDataSerializer, PermissionSerializer
+from .serializers import RefreshSerializer, MyDataSerializer, PermissionSerializer
 from .services import PermissionService
 
 from utils.constants import Cachekey
@@ -193,7 +193,10 @@ class Refresh(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request:HttpRequest, format=None):
-        pass
+        serializer = RefreshSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        grant_type = serializer.validated_data['grant_type']
+        refresh_token = serializer.validated_data['refresh_token']
 
 class MyDataView(APIView):
     permission_classes = [IsAuthenticated]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -16,7 +16,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from urllib.parse import urlencode
 from .serializers import RefreshSerializer, MyDataSerializer, PermissionSerializer
-from .services import PermissionService
+from .services import JWTService, PermissionService
 
 from utils.constants import Cachekey
 from utils.helpers import get_user_id, calc_params_hash
@@ -197,6 +197,11 @@ class Refresh(APIView):
         serializer.is_valid(raise_exception=True)
         grant_type = serializer.validated_data['grant_type']
         refresh_token = serializer.validated_data['refresh_token']
+
+        jwt_service = JWTService(grant_type=grant_type)
+        cookie = jwt_service.refresh(refresh_token=refresh_token)
+
+        return cookie
 
 class MyDataView(APIView):
     permission_classes = [IsAuthenticated]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -14,11 +14,11 @@ from django.shortcuts import redirect
 from django.contrib.auth import get_user_model
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.exceptions import TokenError
-from rest_framework_simplejwt.settings import api_settings
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from urllib.parse import urlencode
 from .serializers import MyDataSerializer, PermissionSerializer
 from .services import JWTService, PermissionService
+from .helpers import response_jwt_cookie
 
 from utils.constants import Cachekey
 from utils.helpers import get_user_id, calc_params_hash
@@ -210,27 +210,12 @@ class Refresh(APIView):
         except Exception:
             raise APIException(detail="토큰 무효화 중 오류가 발생했어요.")
 
-        response = Response(
+        return response_jwt_cookie(
             status=status.HTTP_200_OK,
-            data={"detail": "토큰을 재발급했어요."},
+            detail="토큰을 재발급했어요.",
+            access_token=new_access_token,
+            refresh_token=new_refresh_token,
         )
-        response.set_cookie(
-            key="access",
-            value=new_access_token,
-            max_age=int(api_settings.ACCESS_TOKEN_LIFETIME.total_seconds()),
-            secure=True,
-            httponly=True,
-            samesite="None",
-        )
-        response.set_cookie(
-            key="refresh",
-            value=new_refresh_token,
-            max_age=int(api_settings.REFRESH_TOKEN_LIFETIME.total_seconds()),
-            secure=True,
-            httponly=True,
-            samesite="None",
-        )
-        return response
 
 class MyDataView(APIView):
     permission_classes = [IsAuthenticated]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -26,8 +26,6 @@ from booths.models import Booth, BoothScrap
 from shows.models import Show, ShowScrap
 from searchs.views import search
 
-# Create your views here.
-
 User = get_user_model()
 logger = logging.getLogger(__name__)
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -16,7 +16,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from urllib.parse import urlencode
-from .serializers import RefreshSerializer, MyDataSerializer, PermissionSerializer
+from .serializers import MyDataSerializer, PermissionSerializer
 from .services import JWTService, PermissionService
 
 from utils.constants import Cachekey
@@ -194,12 +194,14 @@ class Refresh(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request:HttpRequest, format=None):
-        serializer = RefreshSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        grant_type = serializer.validated_data['grant_type']
-        old_refresh_token = serializer.validated_data['refresh_token']
+        old_refresh_token = request.COOKIES.get("refresh")
+        if not old_refresh_token:
+            return Response(
+                status=status.HTTP_401_UNAUTHORIZED,
+                data={"detail": "Refresh Token이 없어요."},
+            )
 
-        jwt_service = JWTService(grant_type=grant_type)
+        jwt_service = JWTService()
 
         try:
             new_access_token, new_refresh_token = jwt_service.refresh(old_refresh_token=old_refresh_token)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -4,7 +4,7 @@ from django.db.models import Count, F
 from django.db import IntegrityError
 from .models import User
 from rest_framework import status
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import AuthenticationFailed, PermissionDenied, NotFound, APIException
 from rest_framework.response import Response
 from rest_framework.views import APIView
 import requests
@@ -196,30 +196,18 @@ class Refresh(APIView):
     def post(self, request:HttpRequest, format=None):
         old_refresh_token = request.COOKIES.get("refresh")
         if not old_refresh_token:
-            return Response(
-                status=status.HTTP_401_UNAUTHORIZED,
-                data={"detail": "Refresh Token이 없어요."},
-            )
+            raise AuthenticationFailed(detail="Refresh Token이 없어요.")
 
         jwt_service = JWTService()
 
         try:
             new_access_token, new_refresh_token = jwt_service.refresh(old_refresh_token=old_refresh_token)
         except TokenError:
-            raise Response(
-                status=status.HTTP_401_UNAUTHORIZED,
-                data={"detail": "유효하지 않은 Refresh Token이에요."},
-            )
+            raise AuthenticationFailed(detail="유효하지 않은 Refresh Token이에요.")
         except User.DoesNotExist:
-            raise Response(
-                status=status.HTTP_404_NOT_FOUND,
-                data={"detail": "존재하지 않는 사용자예요."},
-            )
+            raise NotFound(detail="존재하지 않는 사용자예요.")
         except Exception:
-            raise Response(
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                data={"detail": "토큰 무효화 중 오류가 발생했어요."},
-            )
+            raise APIException(detail="토큰 무효화 중 오류가 발생했어요.")
 
         response = Response(
             status=status.HTTP_200_OK,

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -14,6 +14,7 @@ from django.shortcuts import redirect
 from django.contrib.auth import get_user_model
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.settings import api_settings
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from urllib.parse import urlencode
 from .serializers import MyDataSerializer, PermissionSerializer
@@ -213,8 +214,22 @@ class Refresh(APIView):
             status=status.HTTP_200_OK,
             data={"detail": "토큰을 재발급했어요."},
         )
-        response.set_cookie("access", new_access_token, httponly=True, samesite="None", secure=True)
-        response.set_cookie("refresh", new_refresh_token, httponly=True, samesite="None", secure=True)
+        response.set_cookie(
+            key="access",
+            value=new_access_token,
+            max_age=int(api_settings.ACCESS_TOKEN_LIFETIME.total_seconds()),
+            secure=True,
+            httponly=True,
+            samesite="None",
+        )
+        response.set_cookie(
+            key="refresh",
+            value=new_refresh_token,
+            max_age=int(api_settings.REFRESH_TOKEN_LIFETIME.total_seconds()),
+            secure=True,
+            httponly=True,
+            samesite="None",
+        )
         return response
 
 class MyDataView(APIView):


### PR DESCRIPTION
## 🔎 What is this PR?

- [Notion/API 명세서/엑세스 토큰 재발급 API](https://www.notion.so/likelion-ewha/3678432fec7480d5b75dd64c6517abd3)

## ✨ Changes

엑세스 토큰 재발급 API를 구현했습니다.

1. `/accounts/refresh/` 엔드포인트로 요청 받으면, Refresh 뷰를 실행합니다.
2. Request Header의 쿠키에서 Refresh Token을 꺼내고, JWTService의 refresh 메서드를 실행합니다.
3. 서명·만료·blacklist 검증, 페이로드에서 user_id 추출 후 유저 조회, 기존 Refresh Token blacklist 등록을 거쳐 User 기반으로 새 토큰 쌍을 발급합니다.
4. response_jwt_cookie 헬퍼 함수를 통해 Response Body를 가공합니다. `max_age` 옵션을 명시하여 지속 쿠키를 생성합니다.
5. 클라이언트에게 응답합니다.

## 📷 Result

Django Test Framework로 테스트했습니다.

<img src="https://github.com/user-attachments/assets/4496d7e4-13d7-45de-b2fb-3bc9036082ce" />

## 💬 To. Reviewer